### PR TITLE
#36 - Fix test execution for Neo4j 2.2.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,10 @@ env:
     - NEO_VERSION=2.1.6
     - NEO_VERSION=2.1.7
     - NEO_VERSION=2.1.8
-script: "mvn -T4 clean test -Dneo4j.version=${NEO_VERSION}"
+    - NEO_VERSION=2.2.0
+      EXTRA_PROFILES=-Pwith-neo4j-io
+    - NEO_VERSION=2.2.1
+      EXTRA_PROFILES=-Pwith-neo4j-io
+script: "mvn -T4 clean test -Dneo4j.version=${NEO_VERSION} ${EXTRA_PROFILES}"
 after_success:
   - mvn clean test jacoco:report coveralls:report

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,8 @@ env:
     - NEO_VERSION=2.1.4
     - NEO_VERSION=2.1.5
     - NEO_VERSION=2.1.6
+    - NEO_VERSION=2.1.7
+    - NEO_VERSION=2.1.8
 script: "mvn -T4 clean test -Dneo4j.version=${NEO_VERSION}"
 after_success:
   - mvn clean test jacoco:report coveralls:report

--- a/liquigraph-core/pom.xml
+++ b/liquigraph-core/pom.xml
@@ -64,6 +64,21 @@
         </dependency>
     </dependencies>
 
+    <profiles>
+        <profile>
+            <id>with-neo4j-io</id>
+            <dependencies>
+                <dependency>
+                    <groupId>org.neo4j</groupId>
+                    <artifactId>neo4j-io</artifactId>
+                    <version>${neo4j.version}</version>
+                    <type>test-jar</type>
+                    <scope>test</scope>
+                </dependency>
+            </dependencies>
+        </profile>
+    </profiles>
+
     <repositories>
         <repository>
             <id>neo4j-release-repository</id>


### PR DESCRIPTION
As explained by @jexp some time ago, `neo4j-io` (test-jar) is now required.