### PR TITLE
Set language when running tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -54,6 +54,13 @@
                 <artifactId>coveralls-maven-plugin</artifactId>
                 <version>3.0.1</version>
             </plugin>
+            <plugin>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>2.18.1</version>
+                <configuration>
+                    <argLine>-Duser.language=en</argLine>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 


### PR DESCRIPTION
Some tests are language dependent.

They fail with message:
```
    parses_changelog_without_query(org.liquigraph.core.validation.XmlSchemaValidatorTest)  Time elapsed: 0.004 sec  <<< FAILURE!
    java.lang.AssertionError:
    Expecting:
     <["cvc-complex-type.2.4.b : Le contenu de l'élément "changeset" n'est pas complet. L'une des valeurs "{precondition, query}" est attendue."]>
    to contain exactly (and in same order):
     <["cvc-complex-type.2.4.b: The content of element 'changeset' is not complete. One of '{precondition, query}' is expected."]>
    but some elements were not found:
     <["cvc-complex-type.2.4.b: The content of element 'changeset' is not complete. One of '{precondition, query}' is expected."]>
    and others were not expected:
     <["cvc-complex-type.2.4.b : Le contenu de l'élément "changeset" n'est pas complet. L'une des valeurs "{precondition, query}" est attendue."]>

    	at org.liquigraph.core.validation.XmlSchemaValidatorTest.parses_changelog_without_query(XmlSchemaValidatorTest.java:47)
    	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
    	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:57)
    	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
    	at java.lang.reflect.Method.invoke(Method.java:606)
    	at org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:47)
    	at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)
    	at org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:44)
    	at org.junit.internal.runners.statements.InvokeMethod.evaluate(InvokeMethod.java:17)
    	at org.junit.rules.ExpectedException$ExpectedExceptionStatement.evaluate(ExpectedException.java:168)
    	at org.junit.rules.RunRules.evaluate(RunRules.java:20)
    	at org.junit.runners.ParentRunner.runLeaf(ParentRunner.java:271)
    	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:70)
    	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:50)
    	at org.junit.runners.ParentRunner$3.run(ParentRunner.java:238)
    	at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:63)
    	at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:236)
    	at org.junit.runners.ParentRunner.access$000(ParentRunner.java:53)
    	at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:229)
    	at org.junit.runners.ParentRunner.run(ParentRunner.java:309)
    	at org.apache.maven.surefire.junit4.JUnit4Provider.execute(JUnit4Provider.java:252)
    	at org.apache.maven.surefire.junit4.JUnit4Provider.executeTestSet(JUnit4Provider.java:141)
    	at org.apache.maven.surefire.junit4.JUnit4Provider.invoke(JUnit4Provider.java:112)
    	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
    	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:57)
    	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
    	at java.lang.reflect.Method.invoke(Method.java:606)
    	at org.apache.maven.surefire.util.ReflectionUtils.invokeMethodWithArray(ReflectionUtils.java:189)
    	at org.apache.maven.surefire.booter.ProviderFactory$ProviderProxy.invoke(ProviderFactory.java:165)
    	at org.apache.maven.surefire.booter.ProviderFactory.invokeProvider(ProviderFactory.java:85)
    	at org.apache.maven.surefire.booter.ForkedBooter.runSuitesInProcess(ForkedBooter.java:115)
    	at org.apache.maven.surefire.booter.ForkedBooter.main(ForkedBooter.java:75)
```

Configure surefire to run using language en.