### PR TITLE
[#45] Remove ordering constraints

### DIFF
--- a/liquigraph-core/src/main/java/org/liquigraph/core/api/ChangelogDiffMaker.java
+++ b/liquigraph-core/src/main/java/org/liquigraph/core/api/ChangelogDiffMaker.java
@@ -5,7 +5,6 @@ import com.google.common.base.Predicates;
 import org.liquigraph.core.configuration.ExecutionContexts;
 import org.liquigraph.core.model.Changeset;
 import org.liquigraph.core.model.predicates.ChangesetChecksumHasChanged;
-import org.liquigraph.core.model.predicates.ChangesetMatchAnyExecutionContexts;
 import org.liquigraph.core.model.predicates.ChangesetRunOnChange;
 
 import java.util.Collection;
@@ -14,6 +13,7 @@ import static com.google.common.base.Predicates.or;
 import static com.google.common.base.Predicates.not;
 import static com.google.common.base.Predicates.in;
 import static com.google.common.collect.FluentIterable.from;
+import static org.liquigraph.core.model.predicates.ChangesetMatchAnyExecutionContexts.BY_ANY_EXECUTION_CONTEXT;
 import static org.liquigraph.core.model.predicates.ChangesetRunAlways.RUN_ALWAYS;
 
 class ChangelogDiffMaker {
@@ -30,7 +30,7 @@ class ChangelogDiffMaker {
                                        Collection<Changeset> persistedChangesets) {
 
         return from(declaredChangesets)
-            .filter(ChangesetMatchAnyExecutionContexts.BY_ANY_EXECUTION_CONTEXT(executionContexts))
+            .filter(BY_ANY_EXECUTION_CONTEXT(executionContexts))
             .filter(executionFilter(persistedChangesets))
             .toList();
     }

--- a/liquigraph-core/src/main/java/org/liquigraph/core/validation/PersistedChangesetValidator.java
+++ b/liquigraph-core/src/main/java/org/liquigraph/core/validation/PersistedChangesetValidator.java
@@ -17,10 +17,8 @@ import static java.lang.String.format;
 public class PersistedChangesetValidator {
 
     public Collection<String> validate(Collection<Changeset> declaredChangesets, Collection<Changeset> persistedChangesets) {
-        Collection<String> errors = newLinkedList();
-        errors.addAll(validateChecksums(filter(declaredChangesets, not(ChangesetRunOnChange.RUN_ON_CHANGE)), persistedChangesets));
-        errors.addAll(validateOrder(declaredChangesets, persistedChangesets));
-        return errors;
+        Collection<Changeset> changesets = filter(declaredChangesets, not(ChangesetRunOnChange.RUN_ON_CHANGE));
+        return validateChecksums(changesets, persistedChangesets);
     }
 
     private Collection<String> validateChecksums(Collection<Changeset> declaredChangesets, Collection<Changeset> persistedChangesets) {
@@ -46,40 +44,10 @@ public class PersistedChangesetValidator {
 
     }
 
-    private Collection<String> validateOrder(Collection<Changeset> declaredChangesets, Collection<Changeset> persistedChangesets) {
-        Collection<String> errors = newLinkedList();
-
-        int difference = declaredChangesets.size() - persistedChangesets.size();
-        if (difference < 0) {
-            errors.add(format("At least %d declared changeset(s) is/are missing.", Math.abs(difference)));
-            return errors;
-        }
-        for (int i = 0; i < persistedChangesets.size(); i++) {
-            Changeset declared = get(declaredChangesets, i);
-            Changeset persisted = get(persistedChangesets, i);
-            String persistedId = persisted.getId();
-            String declaredId = declared.getId();
-            if (!declaredId.equals(persistedId)) {
-                errors.add(idMismatchError(i, persistedId, declaredId));
-            }
-        }
-
-        return errors;
-    }
-
     private String checksumMismatchError(Changeset declaredChangeset, Changeset persistedChangeset) {
         return format(
             "Changeset with ID <%s> has conflicted checksums.%n\t - Declared: <%s>%n\t - Persisted: <%s>.",
             declaredChangeset.getId(), declaredChangeset.getChecksum(), persistedChangeset.getChecksum()
-        );
-    }
-
-    private String idMismatchError(int i, String persistedId, String declaredId) {
-        return format(
-            "Declared changeset number %d should have%n\t\t - ID:\t <%s> %n\t\t - Found:\t<%s>.",
-            i+1,
-            persistedId,
-            declaredId
         );
     }
 

--- a/liquigraph-core/src/main/java/org/liquigraph/core/writer/ChangelogGraphReader.java
+++ b/liquigraph-core/src/main/java/org/liquigraph/core/writer/ChangelogGraphReader.java
@@ -19,7 +19,7 @@ public class ChangelogGraphReader {
     private static final String MATCH_CHANGESETS =
         "MATCH (changelog:__LiquigraphChangelog)<-[exec:EXECUTED_WITHIN_CHANGELOG]-(changeset:__LiquigraphChangeset) " +
         "RETURN changeset " +
-        "ORDER BY exec.order ASC";
+        "ORDER BY exec.time ASC";
 
     public final Collection<Changeset> read(Connection connection) {
         Collection<Changeset> changesets = newLinkedList();

--- a/liquigraph-core/src/main/java/org/liquigraph/core/writer/PreconditionExecutor.java
+++ b/liquigraph-core/src/main/java/org/liquigraph/core/writer/PreconditionExecutor.java
@@ -18,16 +18,12 @@ import static java.lang.String.format;
 
 public class PreconditionExecutor {
 
-    public final Optional<PreconditionResult> executePrecondition(Connection connection, Precondition precondition) {
-        if (precondition == null) {
-            return absent();
-        }
+    public final PreconditionResult executePrecondition(Connection connection, Precondition precondition) {
         checkArgument(connection != null, "Connection should not be null");
-        PreconditionResult result = new PreconditionResult(
+        return new PreconditionResult(
             precondition.getPolicy(),
             applyPrecondition(connection, precondition.getQuery())
         );
-        return Optional.of(result);
     }
 
     private boolean applyPrecondition(Connection connection, PreconditionQuery query) {

--- a/liquigraph-core/src/test/java/org/liquigraph/core/validation/PersistedChangesetValidatorTest.java
+++ b/liquigraph-core/src/test/java/org/liquigraph/core/validation/PersistedChangesetValidatorTest.java
@@ -63,44 +63,6 @@ public class PersistedChangesetValidatorTest {
         );
     }
 
-    @Test
-    public void fails_if_less_declared_changesets_than_persisted_ones() {
-        Collection<String> errors = validator.validate(
-            newArrayList(changeset("identifier", "author", "MATCH m RETURN m")),
-            newArrayList(
-                changeset("identifier", "author", "MATCH m RETURN m"),
-                changeset("identifier2", "author", "MATCH n RETURN n")
-            )
-        );
-
-        assertThat(errors).containsExactly(
-            "At least 1 declared changeset(s) is/are missing."
-        );
-    }
-
-    @Test
-    public void fails_if_order_of_changelogs_is_different() {
-        Collection<String> errors = validator.validate(
-            newArrayList(
-                changeset("identifier2", "author", "MATCH n RETURN n"),
-                changeset("identifier", "author", "MATCH m RETURN m")
-            ),
-            newArrayList(
-                changeset("identifier", "author", "MATCH m RETURN m"),
-                changeset("identifier2", "author", "MATCH n RETURN n")
-            )
-        );
-
-        assertThat(errors).containsExactly(
-            "Declared changeset number 1 should have\n" +
-                "\t\t - ID:\t <identifier> \n" +
-                "\t\t - Found:\t<identifier2>.",
-            "Declared changeset number 2 should have\n" +
-                "\t\t - ID:\t <identifier2> \n" +
-                "\t\t - Found:\t<identifier>."
-        );
-    }
-
     private Changeset changeset(String identifier, String author, String query, boolean runOnChange) {
         Changeset changeset = changeset(identifier, author, query);
         changeset.setRunOnChange(true);

--- a/liquigraph-core/src/test/java/org/liquigraph/core/writer/PreconditionExecutorTest.java
+++ b/liquigraph-core/src/test/java/org/liquigraph/core/writer/PreconditionExecutorTest.java
@@ -1,6 +1,5 @@
 package org.liquigraph.core.writer;
 
-import com.google.common.base.Optional;
 import com.google.common.collect.Lists;
 import org.junit.Rule;
 import org.junit.Test;
@@ -33,22 +32,14 @@ public class PreconditionExecutorTest {
     private PreconditionExecutor executor = new PreconditionExecutor();
 
     @Test
-    public void returns_no_result_when_precondition_is_null() {
-        Optional<PreconditionResult> result = executor.executePrecondition(graphDatabaseRule.jdbcConnection(), null);
-
-        assertThat(result).isEqualTo(Optional.absent());
-    }
-
-    @Test
     public void executes_simple_precondition() throws SQLException {
         Connection connection = graphDatabaseRule.jdbcConnection();
         try (Statement ignored = connection.createStatement()) {
-            Optional<PreconditionResult> maybeResult = executor.executePrecondition(
+            PreconditionResult result = executor.executePrecondition(
                 connection,
                 simplePrecondition(PreconditionErrorPolicy.MARK_AS_EXECUTED, "RETURN true AS result")
             );
 
-            PreconditionResult result = maybeResult.get();
             assertThat(result.errorPolicy()).isEqualTo(PreconditionErrorPolicy.MARK_AS_EXECUTED);
             assertThat(result.executedSuccessfully()).isTrue();
         }
@@ -58,12 +49,11 @@ public class PreconditionExecutorTest {
     public void executes_nested_and_precondition_queries() throws SQLException {
         Connection connection = graphDatabaseRule.jdbcConnection();
         try (Statement ignored = connection.createStatement()) {
-            Optional<PreconditionResult> maybeResult = executor.executePrecondition(
+            PreconditionResult result = executor.executePrecondition(
                 connection,
                 andPrecondition(PreconditionErrorPolicy.FAIL, "RETURN true AS result", "RETURN false AS result")
             );
 
-            PreconditionResult result = maybeResult.get();
             assertThat(result.errorPolicy()).isEqualTo(PreconditionErrorPolicy.FAIL);
             assertThat(result.executedSuccessfully()).isFalse();
         }
@@ -73,12 +63,11 @@ public class PreconditionExecutorTest {
     public void executes_nested_or_precondition_queries() throws SQLException {
         Connection connection = graphDatabaseRule.jdbcConnection();
         try (Statement ignored = connection.createStatement()) {
-            Optional<PreconditionResult> maybeResult = executor.executePrecondition(
+            PreconditionResult result = executor.executePrecondition(
                 connection,
                 orPrecondition(PreconditionErrorPolicy.CONTINUE, "RETURN true AS result", "RETURN false AS result")
             );
 
-            PreconditionResult result = maybeResult.get();
             assertThat(result.errorPolicy()).isEqualTo(PreconditionErrorPolicy.CONTINUE);
             assertThat(result.executedSuccessfully()).isTrue();
         }
@@ -96,12 +85,11 @@ public class PreconditionExecutorTest {
 
         Connection connection = graphDatabaseRule.jdbcConnection();
         try (Statement ignored = connection.createStatement()) {
-            Optional<PreconditionResult> maybeResult = executor.executePrecondition(
+            PreconditionResult result = executor.executePrecondition(
                 connection,
                 precondition
             );
 
-            PreconditionResult result = maybeResult.get();
             assertThat(result.errorPolicy()).isEqualTo(PreconditionErrorPolicy.MARK_AS_EXECUTED);
             assertThat(result.executedSuccessfully()).isTrue();
         }


### PR DESCRIPTION
Users are now free to re-organize their changesets as they wish.
Checksum validation obviously remains as-is ;-)