### PR TITLE
[#23] Ensure exclusive connection

### DIFF
--- a/liquigraph-core/src/main/java/org/liquigraph/core/exception/LiquigraphLockException.java
+++ b/liquigraph-core/src/main/java/org/liquigraph/core/exception/LiquigraphLockException.java
@@ -13,23 +13,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.liquigraph.core.io;
+package org.liquigraph.core.exception;
 
-import org.liquigraph.core.configuration.Configuration;
+import java.sql.SQLException;
 
-import java.sql.Connection;
+public class LiquigraphLockException extends RuntimeException {
 
-public class FixedConnectionConnector implements LiquigraphJdbcConnector {
-
-    private final Connection connection;
-
-    public FixedConnectionConnector(Connection connection) {
-        this.connection = connection;
+    public LiquigraphLockException(String message, SQLException cause) {
+        super(message, cause);
     }
-
-    @Override
-    public Connection connect(Configuration configuration) {
-        return new KeepAliveConnection(connection);
-    }
-
 }

--- a/liquigraph-core/src/main/java/org/liquigraph/core/exception/PreconditionExecutionException.java
+++ b/liquigraph-core/src/main/java/org/liquigraph/core/exception/PreconditionExecutionException.java
@@ -13,23 +13,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.liquigraph.core.io;
+package org.liquigraph.core.exception;
 
-import org.liquigraph.core.configuration.Configuration;
+import static java.lang.String.format;
 
-import java.sql.Connection;
+public class PreconditionExecutionException extends RuntimeException {
 
-public class FixedConnectionConnector implements LiquigraphJdbcConnector {
-
-    private final Connection connection;
-
-    public FixedConnectionConnector(Connection connection) {
-        this.connection = connection;
+    public PreconditionExecutionException(String message, Object... arguments) {
+        super(format(message, arguments));
     }
-
-    @Override
-    public Connection connect(Configuration configuration) {
-        return new KeepAliveConnection(connection);
-    }
-
 }

--- a/liquigraph-core/src/main/java/org/liquigraph/core/io/GraphJdbcConnector.java
+++ b/liquigraph-core/src/main/java/org/liquigraph/core/io/GraphJdbcConnector.java
@@ -18,6 +18,7 @@ package org.liquigraph.core.io;
 import com.google.common.base.Optional;
 import com.google.common.base.Throwables;
 import org.liquigraph.core.configuration.Configuration;
+import org.liquigraph.core.io.lock.LockableConnection;
 
 import java.sql.Connection;
 import java.sql.DriverManager;
@@ -25,13 +26,21 @@ import java.sql.SQLException;
 
 public class GraphJdbcConnector implements LiquigraphJdbcConnector {
 
+    /**
+     * Acquires a new connection to the configured instance
+     * and tries to lock it (fail-fast).
+     *
+     * @see {@link LockableConnection}
+     * @param configuration Liquigraph settings
+     * @return JDBC connection
+     */
     @Override
     public final Connection connect(Configuration configuration) {
         try {
             Class.forName("org.neo4j.jdbc.Driver");
             Connection connection = DriverManager.getConnection(makeUri(configuration));
             connection.setAutoCommit(false);
-            return connection;
+            return new LockableConnection(connection);
         } catch (ClassNotFoundException | SQLException e) {
             throw Throwables.propagate(e);
         }

--- a/liquigraph-core/src/main/java/org/liquigraph/core/io/GraphJdbcConnector.java
+++ b/liquigraph-core/src/main/java/org/liquigraph/core/io/GraphJdbcConnector.java
@@ -40,7 +40,7 @@ public class GraphJdbcConnector implements LiquigraphJdbcConnector {
             Class.forName("org.neo4j.jdbc.Driver");
             Connection connection = DriverManager.getConnection(makeUri(configuration));
             connection.setAutoCommit(false);
-            return new LockableConnection(connection);
+            return LockableConnection.acquire(connection);
         } catch (ClassNotFoundException | SQLException e) {
             throw Throwables.propagate(e);
         }

--- a/liquigraph-core/src/main/java/org/liquigraph/core/io/PreconditionExecutor.java
+++ b/liquigraph-core/src/main/java/org/liquigraph/core/io/PreconditionExecutor.java
@@ -15,7 +15,7 @@
  */
 package org.liquigraph.core.io;
 
-import org.liquigraph.core.exception.PreconditionException;
+import org.liquigraph.core.exception.PreconditionExecutionException;
 import org.liquigraph.core.model.CompoundQuery;
 import org.liquigraph.core.model.Precondition;
 import org.liquigraph.core.model.PreconditionQuery;
@@ -62,7 +62,7 @@ public class PreconditionExecutor {
             return resultSet.getBoolean("result");
         }
         catch (SQLException e) {
-            throw new PreconditionException("%nError executing precondition:%n" +
+            throw new PreconditionExecutionException("%nError executing precondition:%n" +
                "\tMake sure your query <%s> yields exactly one column named or aliased 'result'.%n" +
                "\tActual cause: %s", query, e.getMessage());
         }

--- a/liquigraph-core/src/main/java/org/liquigraph/core/io/lock/LockableConnection.java
+++ b/liquigraph-core/src/main/java/org/liquigraph/core/io/lock/LockableConnection.java
@@ -1,0 +1,347 @@
+/**
+ * Copyright 2014-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.liquigraph.core.io.lock;
+
+import org.liquigraph.core.exception.LiquigraphLockException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.sql.Array;
+import java.sql.Blob;
+import java.sql.CallableStatement;
+import java.sql.Clob;
+import java.sql.Connection;
+import java.sql.DatabaseMetaData;
+import java.sql.NClob;
+import java.sql.PreparedStatement;
+import java.sql.SQLClientInfoException;
+import java.sql.SQLException;
+import java.sql.SQLWarning;
+import java.sql.SQLXML;
+import java.sql.Savepoint;
+import java.sql.Statement;
+import java.sql.Struct;
+import java.util.Map;
+import java.util.Properties;
+import java.util.UUID;
+import java.util.concurrent.Executor;
+
+/**
+ * This JDBC connection decorator writes a (:__LiquigraphLock)
+ * Neo4j node in order to prevent concurrent executions.
+ *
+ * Closing this connection will delete the created "Lock" node.
+ *
+ * A shutdown hook is executed to remove the lock node if and
+ * only if the connection has not been properly closed.
+ */
+public final class LockableConnection implements Connection {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(LockableConnection.class);
+    private final Connection delegate;
+    private final UUID uuid;
+    private final Thread task;
+
+    public LockableConnection(Connection delegate) {
+        this.delegate = delegate;
+        this.uuid = UUID.randomUUID();
+        this.task = new Thread(new ShutdownTask(this));
+        initiateLocking();
+    }
+
+    /**
+     * Removes lock node and removes the related cleanup
+     * task shutdown hook before closing the underlying
+     * connection.
+     *
+     * @see {@link ShutdownTask}
+     */
+    @Override
+    public void close() throws SQLException {
+        Runtime.getRuntime().removeShutdownHook(task);
+        releaseLock();
+        delegate.close();
+    }
+
+    public Statement createStatement() throws SQLException {
+        return delegate.createStatement();
+    }
+
+    public void commit() throws SQLException {
+        delegate.commit();
+    }
+
+    public NClob createNClob() throws SQLException {
+        return delegate.createNClob();
+    }
+
+    public Map<String, Class<?>> getTypeMap() throws SQLException {
+        return delegate.getTypeMap();
+    }
+
+    public void setHoldability(int holdability) throws SQLException {
+        delegate.setHoldability(holdability);
+    }
+
+    public void releaseSavepoint(Savepoint savepoint) throws SQLException {
+        delegate.releaseSavepoint(savepoint);
+    }
+
+    public Array createArrayOf(String typeName, Object[] elements) throws SQLException {
+        return delegate.createArrayOf(typeName, elements);
+    }
+
+    public void rollback(Savepoint savepoint) throws SQLException {
+        delegate.rollback(savepoint);
+    }
+
+    public PreparedStatement prepareStatement(String sql, int resultSetType, int resultSetConcurrency, int resultSetHoldability) throws SQLException {
+        return delegate.prepareStatement(sql, resultSetType, resultSetConcurrency, resultSetHoldability);
+    }
+
+    public Struct createStruct(String typeName, Object[] attributes) throws SQLException {
+        return delegate.createStruct(typeName, attributes);
+    }
+
+    public void setAutoCommit(boolean autoCommit) throws SQLException {
+        delegate.setAutoCommit(autoCommit);
+    }
+
+    public void setReadOnly(boolean readOnly) throws SQLException {
+        delegate.setReadOnly(readOnly);
+    }
+
+    public String getClientInfo(String name) throws SQLException {
+        return delegate.getClientInfo(name);
+    }
+
+    public void setTransactionIsolation(int level) throws SQLException {
+        delegate.setTransactionIsolation(level);
+    }
+
+    public void setTypeMap(Map<String, Class<?>> map) throws SQLException {
+        delegate.setTypeMap(map);
+    }
+
+    public void setClientInfo(String name, String value) throws SQLClientInfoException {
+        delegate.setClientInfo(name, value);
+    }
+
+    public PreparedStatement prepareStatement(String sql) throws SQLException {
+        return delegate.prepareStatement(sql);
+    }
+
+    public boolean isClosed() throws SQLException {
+        return delegate.isClosed();
+    }
+
+    public boolean isReadOnly() throws SQLException {
+        return delegate.isReadOnly();
+    }
+
+    public Savepoint setSavepoint() throws SQLException {
+        return delegate.setSavepoint();
+    }
+
+    public int getNetworkTimeout() throws SQLException {
+        return delegate.getNetworkTimeout();
+    }
+
+    public String getSchema() throws SQLException {
+        return delegate.getSchema();
+    }
+
+    public String getCatalog() throws SQLException {
+        return delegate.getCatalog();
+    }
+
+    public void setCatalog(String catalog) throws SQLException {
+        delegate.setCatalog(catalog);
+    }
+
+    public boolean isWrapperFor(Class<?> iface) throws SQLException {
+        return delegate.isWrapperFor(iface);
+    }
+
+    public Statement createStatement(int resultSetType, int resultSetConcurrency, int resultSetHoldability) throws SQLException {
+        return delegate.createStatement(resultSetType, resultSetConcurrency, resultSetHoldability);
+    }
+
+    public void abort(Executor executor) throws SQLException {
+        delegate.abort(executor);
+    }
+
+    public DatabaseMetaData getMetaData() throws SQLException {
+        return delegate.getMetaData();
+    }
+
+    public SQLXML createSQLXML() throws SQLException {
+        return delegate.createSQLXML();
+    }
+
+    public void rollback() throws SQLException {
+        delegate.rollback();
+    }
+
+    public CallableStatement prepareCall(String sql, int resultSetType, int resultSetConcurrency, int resultSetHoldability) throws SQLException {
+        return delegate.prepareCall(sql, resultSetType, resultSetConcurrency, resultSetHoldability);
+    }
+
+    public void setNetworkTimeout(Executor executor, int milliseconds) throws SQLException {
+        delegate.setNetworkTimeout(executor, milliseconds);
+    }
+
+    public SQLWarning getWarnings() throws SQLException {
+        return delegate.getWarnings();
+    }
+
+    public boolean getAutoCommit() throws SQLException {
+        return delegate.getAutoCommit();
+    }
+
+    public Clob createClob() throws SQLException {
+        return delegate.createClob();
+    }
+
+    public <T> T unwrap(Class<T> iface) throws SQLException {
+        return delegate.unwrap(iface);
+    }
+
+    public void setClientInfo(Properties properties) throws SQLClientInfoException {
+        delegate.setClientInfo(properties);
+    }
+
+    public int getHoldability() throws SQLException {
+        return delegate.getHoldability();
+    }
+
+    public PreparedStatement prepareStatement(String sql, int resultSetType, int resultSetConcurrency) throws SQLException {
+        return delegate.prepareStatement(sql, resultSetType, resultSetConcurrency);
+    }
+
+    public String nativeSQL(String sql) throws SQLException {
+        return delegate.nativeSQL(sql);
+    }
+
+    public Statement createStatement(int resultSetType, int resultSetConcurrency) throws SQLException {
+        return delegate.createStatement(resultSetType, resultSetConcurrency);
+    }
+
+    public Savepoint setSavepoint(String name) throws SQLException {
+        return delegate.setSavepoint(name);
+    }
+
+    public Properties getClientInfo() throws SQLException {
+        return delegate.getClientInfo();
+    }
+
+    public PreparedStatement prepareStatement(String sql, String[] columnNames) throws SQLException {
+        return delegate.prepareStatement(sql, columnNames);
+    }
+
+    public boolean isValid(int timeout) throws SQLException {
+        return delegate.isValid(timeout);
+    }
+
+    public CallableStatement prepareCall(String sql, int resultSetType, int resultSetConcurrency) throws SQLException {
+        return delegate.prepareCall(sql, resultSetType, resultSetConcurrency);
+    }
+
+    public PreparedStatement prepareStatement(String sql, int autoGeneratedKeys) throws SQLException {
+        return delegate.prepareStatement(sql, autoGeneratedKeys);
+    }
+
+    public Blob createBlob() throws SQLException {
+        return delegate.createBlob();
+    }
+
+    public PreparedStatement prepareStatement(String sql, int[] columnIndexes) throws SQLException {
+        return delegate.prepareStatement(sql, columnIndexes);
+    }
+
+    public int getTransactionIsolation() throws SQLException {
+        return delegate.getTransactionIsolation();
+    }
+
+    public CallableStatement prepareCall(String sql) throws SQLException {
+        return delegate.prepareCall(sql);
+    }
+
+    public void clearWarnings() throws SQLException {
+        delegate.clearWarnings();
+    }
+
+    public void setSchema(String schema) throws SQLException {
+        delegate.setSchema(schema);
+    }
+
+    private final void initiateLocking() {
+        registerLockRemovalHook();
+        ensureLockUnicity();
+        tryWriteLock();
+    }
+
+    final void releaseLock() {
+        try (PreparedStatement statement = prepareStatement(
+            "MATCH (lock:__LiquigraphLock {uuid:{1}}) DELETE lock")) {
+
+            statement.setString(1, uuid.toString());
+            statement.execute();
+            commit();
+        } catch (SQLException e) {
+            LOGGER.error(
+                "Cannot remove __LiquigraphLock during cleanup.",
+                e
+            );
+        }
+    }
+
+    private final void registerLockRemovalHook() {
+        Runtime.getRuntime().addShutdownHook(task);
+    }
+
+    private final void ensureLockUnicity() {
+        try (Statement statement = delegate.createStatement()) {
+            statement.execute("CREATE CONSTRAINT ON (lock:__LiquigraphLock) ASSERT lock.name IS UNIQUE");
+            delegate.commit();
+        }
+        catch (SQLException e) {
+            throw new LiquigraphLockException(
+                "Could not ensure __LiquigraphLock unicity\n\t" +
+                    "Please make sure your instance is in a clean state\n\t" +
+                    "No more than 1 lock should be there simultaneously!",
+                e
+            );
+        }
+    }
+
+    private final void tryWriteLock() {
+        try (PreparedStatement statement = delegate.prepareStatement(
+            "CREATE (:__LiquigraphLock {name:'John', uuid:{1}})")) {
+
+            statement.setString(1, uuid.toString());
+            statement.execute();
+            delegate.commit();
+        }
+        catch (SQLException e) {
+            throw new LiquigraphLockException(
+                "Cannot create __LiquigraphLock lock\n\t" +
+                "Likely another Liquigraph execution is going on or has crashed.",
+                e
+            );
+        }
+    }
+}

--- a/liquigraph-core/src/main/java/org/liquigraph/core/io/lock/ShutdownTask.java
+++ b/liquigraph-core/src/main/java/org/liquigraph/core/io/lock/ShutdownTask.java
@@ -13,13 +13,22 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.liquigraph.core.exception;
+package org.liquigraph.core.io.lock;
 
-import static java.lang.String.format;
+/**
+ * Lock-related cleanup task for {@link LockableConnection}
+ */
+final class ShutdownTask implements Runnable {
 
-public class PreconditionException extends RuntimeException {
+    private final LockableConnection connection;
 
-    public PreconditionException(String message, Object... arguments) {
-        super(format(message, arguments));
+    public ShutdownTask(LockableConnection connection) {
+        this.connection = connection;
     }
+
+    @Override
+    public void run() {
+        connection.releaseLock();
+    }
+
 }

--- a/liquigraph-core/src/test/java/org/liquigraph/core/api/LiquigraphTest.java
+++ b/liquigraph-core/src/test/java/org/liquigraph/core/api/LiquigraphTest.java
@@ -15,6 +15,7 @@
  */
 package org.liquigraph.core.api;
 
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -32,16 +33,14 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 public class LiquigraphTest {
 
-    @Rule
-    public EmbeddedGraphDatabaseRule graph = new EmbeddedGraphDatabaseRule("neo");
-
+    @Rule public EmbeddedGraphDatabaseRule graph = new EmbeddedGraphDatabaseRule("neo");
     private Liquigraph liquigraph;
 
     @Before
     public void prepare() {
         liquigraph = new Liquigraph(
             // bypasses the configured URI
-            new FixedConnectionConnector(graph.jdbcConnection())
+             new FixedConnectionConnector(graph.jdbcConnection())
         );
     }
 

--- a/liquigraph-core/src/test/java/org/liquigraph/core/io/KeepAliveConnection.java
+++ b/liquigraph-core/src/test/java/org/liquigraph/core/io/KeepAliveConnection.java
@@ -1,0 +1,324 @@
+/**
+ * Copyright 2014-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.liquigraph.core.io;
+
+import java.sql.Array;
+import java.sql.Blob;
+import java.sql.CallableStatement;
+import java.sql.Clob;
+import java.sql.Connection;
+import java.sql.DatabaseMetaData;
+import java.sql.NClob;
+import java.sql.PreparedStatement;
+import java.sql.SQLClientInfoException;
+import java.sql.SQLException;
+import java.sql.SQLWarning;
+import java.sql.SQLXML;
+import java.sql.Savepoint;
+import java.sql.Statement;
+import java.sql.Struct;
+import java.util.Map;
+import java.util.Properties;
+import java.util.concurrent.Executor;
+
+/**
+ * Prevents Liquigraph from closing the delegate
+ * before tests can re-use it.
+ *
+ * Related to https://github.com/neo4j-contrib/neo4j-jdbc/issues/55.
+ */
+public class KeepAliveConnection implements Connection {
+
+    private final Connection delegate;
+
+    public KeepAliveConnection(Connection delegate) {
+        this.delegate = delegate;
+    }
+
+
+    public void doClose() throws SQLException {
+        delegate.close();
+    }
+
+    @Override
+    public void close() throws SQLException {
+    }
+
+    @Override
+    public Statement createStatement() throws SQLException {
+        return delegate.createStatement();
+    }
+
+    @Override
+    public PreparedStatement prepareStatement(String sql) throws SQLException {
+        return delegate.prepareStatement(sql);
+    }
+
+    @Override
+    public CallableStatement prepareCall(String sql) throws SQLException {
+        return delegate.prepareCall(sql);
+    }
+
+    @Override
+    public String nativeSQL(String sql) throws SQLException {
+        return delegate.nativeSQL(sql);
+    }
+
+    @Override
+    public void setAutoCommit(boolean autoCommit) throws SQLException {
+        delegate.setAutoCommit(autoCommit);
+    }
+
+    @Override
+    public boolean getAutoCommit() throws SQLException {
+        return delegate.getAutoCommit();
+    }
+
+    @Override
+    public void commit() throws SQLException {
+        delegate.commit();
+    }
+
+    @Override
+    public void rollback() throws SQLException {
+        delegate.rollback();
+    }
+
+    @Override
+    public boolean isClosed() throws SQLException {
+        return delegate.isClosed();
+    }
+
+    @Override
+    public DatabaseMetaData getMetaData() throws SQLException {
+        return delegate.getMetaData();
+    }
+
+    @Override
+    public void setReadOnly(boolean readOnly) throws SQLException {
+        delegate.setReadOnly(readOnly);
+    }
+
+    @Override
+    public boolean isReadOnly() throws SQLException {
+        return delegate.isReadOnly();
+    }
+
+    @Override
+    public void setCatalog(String catalog) throws SQLException {
+        delegate.setCatalog(catalog);
+    }
+
+    @Override
+    public String getCatalog() throws SQLException {
+        return delegate.getCatalog();
+    }
+
+    @Override
+    public void setTransactionIsolation(int level) throws SQLException {
+        delegate.setTransactionIsolation(level);
+    }
+
+    @Override
+    public int getTransactionIsolation() throws SQLException {
+        return delegate.getTransactionIsolation();
+    }
+
+    @Override
+    public SQLWarning getWarnings() throws SQLException {
+        return delegate.getWarnings();
+    }
+
+    @Override
+    public void clearWarnings() throws SQLException {
+        delegate.clearWarnings();
+    }
+
+    @Override
+    public Statement createStatement(int resultSetType, int resultSetConcurrency) throws SQLException {
+        return delegate.createStatement(resultSetType, resultSetConcurrency);
+    }
+
+    @Override
+    public PreparedStatement prepareStatement(String sql, int resultSetType, int resultSetConcurrency) throws SQLException {
+        return delegate.prepareStatement(sql, resultSetType, resultSetConcurrency);
+    }
+
+    @Override
+    public CallableStatement prepareCall(String sql, int resultSetType, int resultSetConcurrency) throws SQLException {
+        return delegate.prepareCall(sql, resultSetType, resultSetConcurrency);
+    }
+
+    @Override
+    public Map<String, Class<?>> getTypeMap() throws SQLException {
+        return delegate.getTypeMap();
+    }
+
+    @Override
+    public void setTypeMap(Map<String, Class<?>> map) throws SQLException {
+        delegate.setTypeMap(map);
+    }
+
+    @Override
+    public void setHoldability(int holdability) throws SQLException {
+        delegate.setHoldability(holdability);
+    }
+
+    @Override
+    public int getHoldability() throws SQLException {
+        return delegate.getHoldability();
+    }
+
+    @Override
+    public Savepoint setSavepoint() throws SQLException {
+        return delegate.setSavepoint();
+    }
+
+    @Override
+    public Savepoint setSavepoint(String name) throws SQLException {
+        return delegate.setSavepoint(name);
+    }
+
+    @Override
+    public void rollback(Savepoint savepoint) throws SQLException {
+        delegate.rollback(savepoint);
+    }
+
+    @Override
+    public void releaseSavepoint(Savepoint savepoint) throws SQLException {
+        delegate.releaseSavepoint(savepoint);
+    }
+
+    @Override
+    public Statement createStatement(int resultSetType, int resultSetConcurrency, int resultSetHoldability) throws SQLException {
+        return delegate.createStatement(resultSetType, resultSetConcurrency, resultSetHoldability);
+    }
+
+    @Override
+    public PreparedStatement prepareStatement(String sql, int resultSetType, int resultSetConcurrency, int resultSetHoldability) throws SQLException {
+        return delegate.prepareStatement(sql, resultSetType, resultSetConcurrency, resultSetHoldability);
+    }
+
+    @Override
+    public CallableStatement prepareCall(String sql, int resultSetType, int resultSetConcurrency, int resultSetHoldability) throws SQLException {
+        return delegate.prepareCall(sql, resultSetType, resultSetConcurrency, resultSetHoldability);
+    }
+
+    @Override
+    public PreparedStatement prepareStatement(String sql, int autoGeneratedKeys) throws SQLException {
+        return delegate.prepareStatement(sql, autoGeneratedKeys);
+    }
+
+    @Override
+    public PreparedStatement prepareStatement(String sql, int[] columnIndexes) throws SQLException {
+        return delegate.prepareStatement(sql, columnIndexes);
+    }
+
+    @Override
+    public PreparedStatement prepareStatement(String sql, String[] columnNames) throws SQLException {
+        return delegate.prepareStatement(sql, columnNames);
+    }
+
+    @Override
+    public Clob createClob() throws SQLException {
+        return delegate.createClob();
+    }
+
+    @Override
+    public Blob createBlob() throws SQLException {
+        return delegate.createBlob();
+    }
+
+    @Override
+    public NClob createNClob() throws SQLException {
+        return delegate.createNClob();
+    }
+
+    @Override
+    public SQLXML createSQLXML() throws SQLException {
+        return delegate.createSQLXML();
+    }
+
+    @Override
+    public boolean isValid(int timeout) throws SQLException {
+        return delegate.isValid(timeout);
+    }
+
+    @Override
+    public void setClientInfo(String name, String value) throws SQLClientInfoException {
+        delegate.setClientInfo(name, value);
+    }
+
+    @Override
+    public void setClientInfo(Properties properties) throws SQLClientInfoException {
+        delegate.setClientInfo(properties);
+    }
+
+    @Override
+    public String getClientInfo(String name) throws SQLException {
+        return delegate.getClientInfo(name);
+    }
+
+    @Override
+    public Properties getClientInfo() throws SQLException {
+        return delegate.getClientInfo();
+    }
+
+    @Override
+    public Array createArrayOf(String typeName, Object[] elements) throws SQLException {
+        return delegate.createArrayOf(typeName, elements);
+    }
+
+    @Override
+    public Struct createStruct(String typeName, Object[] attributes) throws SQLException {
+        return delegate.createStruct(typeName, attributes);
+    }
+
+    @Override
+    public void setSchema(String schema) throws SQLException {
+        delegate.setSchema(schema);
+    }
+
+    @Override
+    public String getSchema() throws SQLException {
+        return delegate.getSchema();
+    }
+
+    @Override
+    public void abort(Executor executor) throws SQLException {
+        delegate.abort(executor);
+    }
+
+    @Override
+    public void setNetworkTimeout(Executor executor, int milliseconds) throws SQLException {
+        delegate.setNetworkTimeout(executor, milliseconds);
+    }
+
+    @Override
+    public int getNetworkTimeout() throws SQLException {
+        return delegate.getNetworkTimeout();
+    }
+
+    @Override
+    public <T> T unwrap(Class<T> iface) throws SQLException {
+        return delegate.unwrap(iface);
+    }
+
+    @Override
+    public boolean isWrapperFor(Class<?> iface) throws SQLException {
+        return delegate.isWrapperFor(iface);
+    }
+}

--- a/liquigraph-core/src/test/java/org/liquigraph/core/io/PreconditionExecutorTest.java
+++ b/liquigraph-core/src/test/java/org/liquigraph/core/io/PreconditionExecutorTest.java
@@ -20,7 +20,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 import org.liquigraph.core.EmbeddedGraphDatabaseRule;
-import org.liquigraph.core.exception.PreconditionException;
+import org.liquigraph.core.exception.PreconditionExecutionException;
 import org.liquigraph.core.model.AndQuery;
 import org.liquigraph.core.model.OrQuery;
 import org.liquigraph.core.model.Precondition;
@@ -112,7 +112,7 @@ public class PreconditionExecutorTest {
 
     @Test
     public void fails_with_invalid_cypher_query() throws SQLException {
-        thrown.expect(PreconditionException.class);
+        thrown.expect(PreconditionExecutionException.class);
         thrown.expectMessage(
             "Error executing precondition:\n" +
             "\tMake sure your query <toto> yields exactly one column named or aliased 'result'.\n" +
@@ -130,7 +130,7 @@ public class PreconditionExecutorTest {
 
     @Test
     public void fails_with_badly_named_precondition_result_column() throws SQLException {
-        thrown.expect(PreconditionException.class);
+        thrown.expect(PreconditionExecutionException.class);
         thrown.expectMessage("Make sure your query <RETURN true> yields exactly one column named or aliased 'result'.");
 
         Connection connection = graphDatabaseRule.jdbcConnection();

--- a/liquigraph-core/src/test/resources/logback-test.xml
+++ b/liquigraph-core/src/test/resources/logback-test.xml
@@ -1,0 +1,20 @@
+<!--
+
+    Copyright 2014-2016 the original author or authors.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+         http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<configuration>
+    <root level="off" />
+</configuration>


### PR DESCRIPTION
The idea is to create an unique lock node and fail fast if the
situation does not allow it. This does not guarantee a particular
execution acquires the connection. However, this mechanism makes
sure only 1 of concurrent executions wins.

The shutdown hook makes sure only the owned lock is deleted when
the execution properly terminates.

This is of course a best effort: JVM hooks are not called under
some unrecoverable circumstances. There may always be locked
instances in some undesirable situations but the window of such
opportunities is now greatly reduced.