### PR TITLE
[#30] Mute Restlet logs triggered by JDBC driver

### DIFF
--- a/liquigraph-core/src/main/java/org/liquigraph/core/configuration/ConfigurationBuilder.java
+++ b/liquigraph-core/src/main/java/org/liquigraph/core/configuration/ConfigurationBuilder.java
@@ -19,9 +19,11 @@ import com.google.common.base.Joiner;
 import com.google.common.base.Optional;
 import org.liquigraph.core.configuration.validators.ExecutionModeValidator;
 import org.liquigraph.core.configuration.validators.MandatoryOptionValidator;
+import org.restlet.engine.Engine;
 
 import java.nio.file.Path;
 import java.util.Collection;
+import java.util.logging.Level;
 
 import static com.google.common.base.Optional.absent;
 import static com.google.common.base.Optional.fromNullable;
@@ -160,6 +162,8 @@ public final class ConfigurationBuilder {
         if (!errors.isEmpty()) {
             throw new RuntimeException(formatErrors(errors));
         }
+
+        muteRestletLogs();
         return new Configuration(
             classLoader,
             masterChangelog,
@@ -169,6 +173,10 @@ public final class ConfigurationBuilder {
             executionContexts,
             executionMode
         );
+    }
+
+    private void muteRestletLogs() {
+        Engine.setRestletLogLevel(Level.SEVERE);
     }
 
     private String formatErrors(Collection<String> errors) {


### PR DESCRIPTION
Currently, Neo4j JDBC driver (v2.0.2) uses Restlet (v2.1.7) and
this version of Restlet only offers programmatic and proprietary 
access to their internal logging (current online docs on the topic 
apply only to 2.2.* and 2.3.*).

This is quite a rigid configuration at this moment, but the least
expensive at hand (JDBC driver upgrade is not an option: it would
require a bump from Neo4j 2.0.* to 2.1.* as min version).