### PR TITLE
Using the EXECUTED_WITHIN_CHANGESET order when reading the Changesets + Flag to use tarFileMode of Posix

### DIFF
--- a/liquigraph-cli/pom.xml
+++ b/liquigraph-cli/pom.xml
@@ -57,6 +57,7 @@
                 <version>2.6</version>
                 <configuration>
                     <descriptor>src/assembly/assembly.xml</descriptor>
+                    <tarLongFileMode>posix</tarLongFileMode>
                 </configuration>
                 <executions>
                     <execution>

--- a/liquigraph-core/src/main/java/org/liquigraph/core/io/ChangelogGraphReader.java
+++ b/liquigraph-core/src/main/java/org/liquigraph/core/io/ChangelogGraphReader.java
@@ -35,9 +35,9 @@ public class ChangelogGraphReader {
     private static final String MATCH_CHANGESETS =
         "MATCH (changelog:__LiquigraphChangelog)<-[exec:EXECUTED_WITHIN_CHANGELOG]-(changeset:__LiquigraphChangeset) " +
             "WITH changeset, exec " +
-            "MATCH (changeset)<-[execChangeset:EXECUTED_WITHIN_CHANGESET]-(query:__LiquigraphQuery) " +
+            "MATCH (changeset)<-[execChangeSet:EXECUTED_WITHIN_CHANGESET]-(query:__LiquigraphQuery) " +
             "WITH changeset, query, exec " +
-            "ORDER BY exec.time ASC, execChangeset.order ASC " +
+            "ORDER BY exec.time ASC, execChangeSet.order ASC " +
             "WITH changeset, COLLECT(query.query) AS queries, exec " +
             "RETURN {" +
             "   id: changeset.id, " +
@@ -54,7 +54,8 @@ public class ChangelogGraphReader {
                 changesets.add(mapRow(result.getObject("changeset")));
             }
             connection.commit();
-        } catch (SQLException e) {
+        }
+        catch (SQLException e) {
             throw propagate(e);
         }
         return changesets;
@@ -68,7 +69,9 @@ public class ChangelogGraphReader {
         if (line instanceof Map) {
             return changeset((Map<String, Object>) line);
         }
-        throw new IllegalArgumentException(format("Unsupported row.\n\t" + "Cannot parse: %s", line));
+        throw new IllegalArgumentException(format(
+           "Unsupported row.\n\t" +
+           "Cannot parse: %s", line));
     }
 
     private Changeset changeset(Node node) {

--- a/liquigraph-core/src/main/java/org/liquigraph/core/io/ChangelogGraphReader.java
+++ b/liquigraph-core/src/main/java/org/liquigraph/core/io/ChangelogGraphReader.java
@@ -34,17 +34,17 @@ public class ChangelogGraphReader {
 
     private static final String MATCH_CHANGESETS =
         "MATCH (changelog:__LiquigraphChangelog)<-[exec:EXECUTED_WITHIN_CHANGELOG]-(changeset:__LiquigraphChangeset) " +
-        "WITH changeset, exec " +
-        "MATCH (changeset)<-[:EXECUTED_WITHIN_CHANGESET]-(query:__LiquigraphQuery) " +
-        "WITH changeset, query, exec " +
-        "ORDER BY exec.time ASC, query.order ASC " +
-        "WITH changeset, COLLECT(query.query) AS queries, exec " +
-        "RETURN {" +
-        "   id: changeset.id, " +
-        "   author:changeset.author, " +
-        "   checksum:changeset.checksum, " +
-        "   query:queries" +
-        "} AS changeset";
+            "WITH changeset, exec " +
+            "MATCH (changeset)<-[execChangeset:EXECUTED_WITHIN_CHANGESET]-(query:__LiquigraphQuery) " +
+            "WITH changeset, query, exec " +
+            "ORDER BY exec.time ASC, execChangeset.order ASC " +
+            "WITH changeset, COLLECT(query.query) AS queries, exec " +
+            "RETURN {" +
+            "   id: changeset.id, " +
+            "   author:changeset.author, " +
+            "   checksum:changeset.checksum, " +
+            "   query:queries" +
+            "} AS changeset";
 
     public final Collection<Changeset> read(Connection connection) {
         Collection<Changeset> changesets = newLinkedList();
@@ -54,8 +54,7 @@ public class ChangelogGraphReader {
                 changesets.add(mapRow(result.getObject("changeset")));
             }
             connection.commit();
-        }
-        catch (SQLException e) {
+        } catch (SQLException e) {
             throw propagate(e);
         }
         return changesets;
@@ -69,9 +68,7 @@ public class ChangelogGraphReader {
         if (line instanceof Map) {
             return changeset((Map<String, Object>) line);
         }
-        throw new IllegalArgumentException(format(
-           "Unsupported row.\n\t" +
-           "Cannot parse: %s", line));
+        throw new IllegalArgumentException(format("Unsupported row.\n\t" + "Cannot parse: %s", line));
     }
 
     private Changeset changeset(Node node) {

--- a/liquigraph-core/src/test/java/org/liquigraph/core/io/ChangelogGraphReaderTest.java
+++ b/liquigraph-core/src/test/java/org/liquigraph/core/io/ChangelogGraphReaderTest.java
@@ -39,13 +39,16 @@ public class ChangelogGraphReaderTest {
     public void reads_changelog_from_graph_database() throws SQLException {
         try (Connection connection = graph.jdbcConnection()) {
             String query = "MATCH n RETURN n";
-            given_inserted_data(format("CREATE (:__LiquigraphChangelog)<-[:EXECUTED_WITHIN_CHANGELOG {time:1}]-" +
+            given_inserted_data(format(
+                "CREATE (:__LiquigraphChangelog)<-[:EXECUTED_WITHIN_CHANGELOG {time:1}]-" +
                     "(:__LiquigraphChangeset {" +
                     "   author:'fbiville'," +
                     "   id:'test'," +
                     "   checksum:'%s'" +
-                    "})<-[:EXECUTED_WITHIN_CHANGESET]-(:__LiquigraphQuery {query: '%s'})", checksum(singletonList(query)),
-                query), connection);
+                    "})<-[:EXECUTED_WITHIN_CHANGESET]-(:__LiquigraphQuery {query: '%s'})"
+                , checksum(singletonList(query)), query),
+                connection
+            );
 
             Collection<Changeset> changesets = reader.read(graph.jdbcConnection());
 
@@ -62,55 +65,34 @@ public class ChangelogGraphReaderTest {
     @Test
     public void reads_changeset_with_multiple_queries() throws SQLException {
         try (Connection connection = graph.jdbcConnection()) {
-            given_inserted_data(format("CREATE     (:__LiquigraphChangelog)<-[:EXECUTED_WITHIN_CHANGELOG {time:1}]-" +
+            given_inserted_data(format(
+                "CREATE     (:__LiquigraphChangelog)<-[:EXECUTED_WITHIN_CHANGELOG {time:1}]-" +
                     "           (changeset:__LiquigraphChangeset {" +
                     "               author:'fbiville'," +
                     "               id:'test'," +
                     "               checksum:'%s'" +
                     "           }), " +
-                    "           (changeset)<-[:EXECUTED_WITHIN_CHANGESET {order: 0}]-(:__LiquigraphQuery {query: '%s'}), " +
-                    "           (changeset)<-[:EXECUTED_WITHIN_CHANGESET {order: 1}]-(:__LiquigraphQuery {query: '%s'})",
-                checksum(asList("MATCH n RETURN n", "MATCH m RETURN m")), "MATCH n RETURN n", "MATCH m RETURN m"),
-                connection);
+                    "           (changeset)<-[:EXECUTED_WITHIN_CHANGESET {order: 1} ]-(:__LiquigraphQuery {query: '%s'}), " +
+                    "           (changeset)<-[:EXECUTED_WITHIN_CHANGESET {order: 0} ]-(:__LiquigraphQuery {query: '%s'}), " +
+                    "           (changeset)<-[:EXECUTED_WITHIN_CHANGESET {order: 2}]-(:__LiquigraphQuery {query: '%s'})",
+                checksum(asList("MATCH m RETURN m", "MATCH n RETURN n", "Match o Return o")),
+                "MATCH n RETURN n",
+                "MATCH m RETURN m",
+                "MATCH o RETURN o"),
+                connection
+            );
 
             Collection<Changeset> changesets = reader.read(graph.jdbcConnection());
 
             assertThat(changesets).hasSize(1);
             Changeset changeset = changesets.iterator().next();
             assertThat(changeset.getId()).isEqualTo("test");
-            assertThat(changeset.getChecksum()).isEqualTo(checksum(asList("MATCH n RETURN n", "MATCH m RETURN m")));
+            assertThat(changeset.getChecksum()).isEqualTo(checksum(asList("MATCH m RETURN m", "MATCH n RETURN n", "Match o Return o")));
             assertThat(changeset.getAuthor()).isEqualTo("fbiville");
-            assertThat(changeset.getQueries()).containsExactly("MATCH n RETURN n", "MATCH m RETURN m");
+            assertThat(changeset.getQueries()).containsExactly("MATCH m RETURN m", "MATCH n RETURN n", "MATCH o RETURN o");
             connection.commit();
         }
     }
-
-    @Test
-    public void reads_changeset_with_multiple_queries_in_order() throws SQLException {
-        try (Connection connection = graph.jdbcConnection()) {
-            given_inserted_data(format("CREATE     (:__LiquigraphChangelog)<-[:EXECUTED_WITHIN_CHANGELOG {time:1}]-" +
-                    "           (changeset:__LiquigraphChangeset {" +
-                    "               author:'fbiville'," +
-                    "               id:'test_in_order'," +
-                    "               checksum:'%s'" +
-                    "           }), " +
-                    "           (changeset)<-[:EXECUTED_WITHIN_CHANGESET {order: 1}]-(:__LiquigraphQuery {query: '%s'}), " +
-                    "           (changeset)<-[:EXECUTED_WITHIN_CHANGESET {order: 0}]-(:__LiquigraphQuery {query: '%s'})",
-                checksum(asList("MATCH m RETURN m","MATCH n RETURN n")), "MATCH n RETURN n", "MATCH m RETURN m"),
-                connection);
-
-            Collection<Changeset> changesets = reader.read(graph.jdbcConnection());
-
-            assertThat(changesets).hasSize(1);
-            Changeset changeset = changesets.iterator().next();
-            assertThat(changeset.getId()).isEqualTo("test_in_order");
-            assertThat(changeset.getChecksum()).isEqualTo(checksum(asList("MATCH m RETURN m", "MATCH n RETURN n")));
-            assertThat(changeset.getAuthor()).isEqualTo("fbiville");
-            assertThat(changeset.getQueries()).containsExactly("MATCH m RETURN m","MATCH n RETURN n");
-            connection.commit();
-        }
-    }
-
 
     private void given_inserted_data(String query, Connection connection) throws SQLException {
         connection.createStatement().executeQuery(query);


### PR DESCRIPTION
Refers to ticket #56  and I also added a flag to the maven-assembly-plugin in the cli project that kept me from building the project. Got the fix from [this issue] (https://github.com/elastic/elasticsearch/issues/11824).