### PR TITLE
Changeset unicity

### DIFF
--- a/liquigraph-core/pom.xml
+++ b/liquigraph-core/pom.xml
@@ -12,6 +12,10 @@
     <name>liquigraph-core</name>
     <packaging>jar</packaging>
 
+    <properties>
+        <guava.version>18.0</guava.version>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>org.neo4j</groupId>
@@ -26,7 +30,7 @@
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
-            <version>18.0</version>
+            <version>${guava.version}</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>
@@ -43,6 +47,12 @@
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <version>4.12</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava-testlib</artifactId>
+            <version>${guava.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/liquigraph-core/src/main/java/org/liquigraph/core/io/ChangelogGraphWriter.java
+++ b/liquigraph-core/src/main/java/org/liquigraph/core/io/ChangelogGraphWriter.java
@@ -36,10 +36,9 @@ public class ChangelogGraphWriter implements ChangelogWriter {
 
     private static final String CHANGESET_UPSERT =
         "MERGE (changelog:__LiquigraphChangelog) " +
-        "MERGE (changelog)<-[ewc:EXECUTED_WITHIN_CHANGELOG]-(changeset:__LiquigraphChangeset {id: {1}}) " +
+        "MERGE (changelog)<-[ewc:EXECUTED_WITHIN_CHANGELOG]-(changeset:__LiquigraphChangeset {id: {1}, author: {3}}) " +
         "ON MATCH SET  changeset.checksum = {2} " +
         "ON CREATE SET changeset.checksum = {2}, " +
-        "              changeset.author = {3}, " +
         "              ewc.time = timestamp() " +
         "WITH changeset " +
         // deletes previous stored queries, if any

--- a/liquigraph-core/src/main/java/org/liquigraph/core/model/Changeset.java
+++ b/liquigraph-core/src/main/java/org/liquigraph/core/model/Changeset.java
@@ -27,7 +27,6 @@ import java.util.Objects;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Strings.nullToEmpty;
 import static com.google.common.collect.Lists.newArrayList;
-import static java.lang.String.format;
 import static org.liquigraph.core.model.Checksums.checksum;
 
 public class Changeset {
@@ -88,7 +87,7 @@ public class Changeset {
 
     @XmlAttribute(name = "contexts", required = false)
     String getContexts() {
-        return executionsContexts == null ? "" : Joiner.on(',').join(executionsContexts);
+        return Joiner.on(',').join(executionsContexts);
     }
 
     public void setContexts(String executionsContexts) {
@@ -127,7 +126,7 @@ public class Changeset {
 
     @Override
     public int hashCode() {
-        return Objects.hash(id, checksum);
+        return Objects.hash(id, author, checksum);
     }
 
     @Override
@@ -139,7 +138,9 @@ public class Changeset {
             return false;
         }
         final Changeset other = (Changeset) obj;
-        return Objects.equals(this.id, other.id) && Objects.equals(this.checksum, other.checksum);
+        return Objects.equals(this.id, other.id) &&
+                Objects.equals(this.author, other.author) &&
+                Objects.equals(this.checksum, other.checksum);
     }
 
     @Override

--- a/liquigraph-core/src/main/java/org/liquigraph/core/model/predicates/ChangesetById.java
+++ b/liquigraph-core/src/main/java/org/liquigraph/core/model/predicates/ChangesetById.java
@@ -23,18 +23,22 @@ import static com.google.common.base.Preconditions.checkState;
 public class ChangesetById implements Predicate<Changeset> {
 
     private final String id;
+    private final String author;
 
-    private ChangesetById(String id) {
+    private ChangesetById(String id, String author) {
         this.id = id;
+        this.author = author;
         checkState(id != null);
+        checkState(author != null);
     }
 
-    public static Predicate<Changeset> BY_ID(String id) {
-        return new ChangesetById(id);
+    public static Predicate<Changeset> BY_ID(String id, String author) {
+        return new ChangesetById(id, author);
     }
 
     @Override
     public boolean apply(Changeset input) {
-        return id.equals(input.getId());
+        return id.equals(input.getId()) &&
+               author.equals(input.getAuthor());
     }
 }

--- a/liquigraph-core/src/main/java/org/liquigraph/core/model/predicates/ChangesetChecksumHasChanged.java
+++ b/liquigraph-core/src/main/java/org/liquigraph/core/model/predicates/ChangesetChecksumHasChanged.java
@@ -38,7 +38,8 @@ public class ChangesetChecksumHasChanged implements Predicate<Changeset> {
 
     @Override
     public boolean apply(Changeset input) {
-        Optional<Changeset> persistedChangeset = from(persistedChangesets).firstMatch(BY_ID(input.getId()));
+        Optional<Changeset> persistedChangeset =
+                from(persistedChangesets).firstMatch(BY_ID(input.getId(), input.getAuthor()));
         return persistedChangeset.isPresent() && !input.getChecksum().equals(persistedChangeset.get().getChecksum());
     }
 }

--- a/liquigraph-core/src/main/java/org/liquigraph/core/model/predicates/ChangesetChecksumHasChanged.java
+++ b/liquigraph-core/src/main/java/org/liquigraph/core/model/predicates/ChangesetChecksumHasChanged.java
@@ -32,13 +32,13 @@ public class ChangesetChecksumHasChanged implements Predicate<Changeset> {
         this.persistedChangesets = persistedChangesets;
     }
 
-    public static final Predicate<Changeset> CHECKSUM_HAS_CHANGED(Collection<Changeset> persistedChangesets) {
+    public static Predicate<Changeset> CHECKSUM_HAS_CHANGED(Collection<Changeset> persistedChangesets) {
         return new ChangesetChecksumHasChanged(persistedChangesets);
     }
 
     @Override
     public boolean apply(Changeset input) {
         Optional<Changeset> persistedChangeset = from(persistedChangesets).firstMatch(BY_ID(input.getId()));
-        return persistedChangeset.isPresent() && input.getChecksum().equals(persistedChangeset.get().getChecksum());
+        return persistedChangeset.isPresent() && !input.getChecksum().equals(persistedChangeset.get().getChecksum());
     }
 }

--- a/liquigraph-core/src/main/java/org/liquigraph/core/validation/PersistedChangesetValidator.java
+++ b/liquigraph-core/src/main/java/org/liquigraph/core/validation/PersistedChangesetValidator.java
@@ -39,7 +39,7 @@ public class PersistedChangesetValidator {
         Collection<String> errors = newLinkedList();
         for (Changeset declaredChangeset : declaredChangesets) {
             Optional<Changeset> maybePersistedChangeset = FluentIterable.from(persistedChangesets)
-                .firstMatch(ChangesetById.BY_ID(declaredChangeset.getId()));
+                .firstMatch(ChangesetById.BY_ID(declaredChangeset.getId(), declaredChangeset.getAuthor()));
 
             if (!maybePersistedChangeset.isPresent()) {
                 continue;
@@ -60,8 +60,9 @@ public class PersistedChangesetValidator {
 
     private String checksumMismatchError(Changeset declaredChangeset, Changeset persistedChangeset) {
         return format(
-            "Changeset with ID <%s> has conflicted checksums.%n\t - Declared: <%s>%n\t - Persisted: <%s>.",
-            declaredChangeset.getId(), declaredChangeset.getChecksum(), persistedChangeset.getChecksum()
+            "Changeset with ID <%s> and author <%s> has conflicted checksums.%n\t - Declared: <%s>%n\t - Persisted: <%s>.",
+            declaredChangeset.getId(), declaredChangeset.getAuthor(), declaredChangeset.getChecksum(),
+            persistedChangeset.getChecksum()
         );
     }
 

--- a/liquigraph-core/src/test/java/org/liquigraph/core/api/ChangelogDiffMakerTest.java
+++ b/liquigraph-core/src/test/java/org/liquigraph/core/api/ChangelogDiffMakerTest.java
@@ -34,11 +34,16 @@ public class ChangelogDiffMakerTest {
     public void diff_includes_all_latest_changesets_with_default_execution_context() {
         Collection<Changeset> changesets = diffMaker.computeChangesetsToInsert(
             DEFAULT_CONTEXT,
-            newArrayList(changeset("ID", "fbiville", "CREATE n"), changeset("ID2", "fbiville", "CREATE m")),
+            newArrayList(
+                changeset("ID", "fbiville", "CREATE n"),
+                changeset("ID", "author2", "CREATE m"),
+                changeset("ID2", "fbiville", "CREATE m")),
             newArrayList(changeset("ID", "fbiville", "CREATE n"))
         );
 
-        assertThat(changesets).containsExactly(changeset("ID2", "fbiville", "CREATE m"));
+        assertThat(changesets).containsExactly(
+            changeset("ID", "author2", "CREATE m"),
+            changeset("ID2", "fbiville", "CREATE m"));
     }
 
     @Test

--- a/liquigraph-core/src/test/java/org/liquigraph/core/api/ChangelogDiffMakerTest.java
+++ b/liquigraph-core/src/test/java/org/liquigraph/core/api/ChangelogDiffMakerTest.java
@@ -122,6 +122,17 @@ public class ChangelogDiffMakerTest {
     }
 
     @Test
+    public void diff_does_not_include_run_on_change_changesets_that_were_not_altered_since_last_execution() {
+        Collection<Changeset> changesets = diffMaker.computeChangesetsToInsert(
+            DEFAULT_CONTEXT,
+            newArrayList(changeset("ID", "fbiville", "CREATE n", "baz", false, true)),
+            newArrayList(changeset("ID", "fbiville", "CREATE n"))
+        );
+
+        assertThat(changesets).isEmpty();
+    }
+
+    @Test
     public void diff_does_not_include_run_on_change_changesets_if_they_do_not_match_any_execution_context() {
         Collection<Changeset> changesets = diffMaker.computeChangesetsToInsert(
             new ExecutionContexts(newArrayList("foo", "bar")),

--- a/liquigraph-core/src/test/java/org/liquigraph/core/model/ChangesetTest.java
+++ b/liquigraph-core/src/test/java/org/liquigraph/core/model/ChangesetTest.java
@@ -1,0 +1,84 @@
+/**
+ * Copyright 2014-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.liquigraph.core.model;
+
+import com.google.common.testing.EqualsTester;
+import org.junit.Test;
+
+import java.util.Collections;
+
+import static java.util.Collections.singletonList;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ChangesetTest {
+    @Test(expected = IllegalArgumentException.class)
+    public void should_fail_with_null_queries() {
+        new Changeset().setQueries(null);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void should_fail_with_empty_queries() {
+        new Changeset().setQueries(Collections.<String>emptyList());
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void should_fail_with_null_checksum() {
+        new Changeset().setChecksum(null);
+    }
+
+    @Test
+    public void should_split_execution_contexts_from_contexts() {
+        Changeset changeset = new Changeset();
+        changeset.setContexts("ctx1, ctx2");
+
+        assertThat(changeset.getExecutionsContexts()).containsOnly("ctx1", "ctx2");
+    }
+
+    @Test
+    public void should_join_contexts_from_execution_contexts() {
+        Changeset changeset = new Changeset();
+        changeset.setContexts("ctx1, ctx2");
+
+        assertThat(changeset.getContexts()).isEqualTo("ctx1,ctx2");
+    }
+
+    @Test
+    public void should_get_empty_contexts_as_default() {
+        Changeset changeset = new Changeset();
+
+        assertThat(changeset.getContexts()).isEmpty();
+    }
+
+    @Test
+    public void should_have_equality_on_id_author_and_checksum() {
+        new EqualsTester()
+            .addEqualityGroup(
+                changeset("identifier", "author", "CREATE (n)"),
+                changeset("identifier", "author", "CREATE (n)"))
+            .addEqualityGroup(changeset("identifier", "author", "MATCH (n) RETURN n"))
+            .addEqualityGroup(changeset("identifier", "author2", "CREATE (n)"))
+            .addEqualityGroup(changeset("identifier2", "author", "CREATE (n)"))
+            .testEquals();
+    }
+
+    private Changeset changeset(String id, String author, String query) {
+        Changeset changeset = new Changeset();
+        changeset.setId(id);
+        changeset.setAuthor(author);
+        changeset.setQueries(singletonList(query));
+        return changeset;
+    }
+}

--- a/liquigraph-core/src/test/java/org/liquigraph/core/model/predicates/ChangesetByIdTest.java
+++ b/liquigraph-core/src/test/java/org/liquigraph/core/model/predicates/ChangesetByIdTest.java
@@ -1,0 +1,67 @@
+/**
+ * Copyright 2014-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.liquigraph.core.model.predicates;
+
+import com.google.common.base.Predicate;
+import org.junit.Test;
+import org.liquigraph.core.model.Changeset;
+
+import static java.util.Collections.singletonList;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ChangesetByIdTest {
+    @Test
+    public void should_match_with_same_id_and_author() {
+        Changeset changeset = changeset("identifier", "author", "MATCH (n) RETURN n");
+        Predicate<Changeset> byId = ChangesetById.BY_ID("identifier", "author");
+
+        assertThat(byId.apply(changeset)).isTrue();
+    }
+
+    @Test
+    public void should_not_match_with_same_id_but_different_author() {
+        Changeset changeset = changeset("identifier", "author", "MATCH (n) RETURN n");
+        Predicate<Changeset> byId = ChangesetById.BY_ID("identifier", "author2");
+
+        assertThat(byId.apply(changeset)).isFalse();
+    }
+
+    @Test
+    public void should_not_match_with_same_author_but_different_id() {
+        Changeset changeset = changeset("identifier", "author", "MATCH (n) RETURN n");
+        Predicate<Changeset> byId = ChangesetById.BY_ID("identifier2", "author");
+
+        assertThat(byId.apply(changeset)).isFalse();
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void should_fail_with_no_identifier() {
+        ChangesetById.BY_ID(null, "author");
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void should_fail_with_no_author() {
+        ChangesetById.BY_ID("identifier", null);
+    }
+
+    private Changeset changeset(String id, String author, String query) {
+        Changeset changeset = new Changeset();
+        changeset.setId(id);
+        changeset.setAuthor(author);
+        changeset.setQueries(singletonList(query));
+        return changeset;
+    }
+}

--- a/liquigraph-core/src/test/java/org/liquigraph/core/model/predicates/ChangesetChecksumHasChangedTest.java
+++ b/liquigraph-core/src/test/java/org/liquigraph/core/model/predicates/ChangesetChecksumHasChangedTest.java
@@ -1,0 +1,61 @@
+/**
+ * Copyright 2014-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.liquigraph.core.model.predicates;
+
+import com.google.common.base.Predicate;
+import org.junit.Test;
+import org.liquigraph.core.model.Changeset;
+
+import java.util.Collections;
+
+import static java.util.Collections.singletonList;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.liquigraph.core.model.predicates.ChangesetChecksumHasChanged.CHECKSUM_HAS_CHANGED;
+
+public class ChangesetChecksumHasChangedTest {
+    @Test
+    public void should_match_a_persisted_changeset_with_changed_checksum() {
+        Changeset changeset = changeset("identifier", "author", "MATCH (n) RETURN n");
+        Predicate<Changeset> checksumHasChanged =
+                CHECKSUM_HAS_CHANGED(singletonList(changeset(changeset.getId(), changeset.getAuthor(), "CREATE (n)")));
+
+        assertThat(checksumHasChanged.apply(changeset)).isTrue();
+    }
+
+    @Test
+    public void should_not_match_a_persisted_changeset_with_unchanged_checksum() {
+        Changeset changeset = changeset("identifier", "author", "MATCH (n) RETURN n");
+        Predicate<Changeset> checksumHasChanged = CHECKSUM_HAS_CHANGED(singletonList(changeset));
+
+        assertThat(checksumHasChanged.apply(changeset)).isFalse();
+    }
+
+    @Test
+    public void should_not_match_a_changeset_not_persisted() {
+        Changeset changeset = changeset("identifier", "author", "MATCH (n) RETURN n");
+        Predicate<Changeset> checksumHasChanged = CHECKSUM_HAS_CHANGED(Collections.<Changeset>emptyList());
+
+        assertThat(checksumHasChanged.apply(changeset)).isFalse();
+    }
+
+    private Changeset changeset(String id, String author, String query) {
+        Changeset changeset = new Changeset();
+        changeset.setId(id);
+        changeset.setAuthor(author);
+        changeset.setQueries(singletonList(query));
+        return changeset;
+    }
+}

--- a/liquigraph-core/src/test/java/org/liquigraph/core/validation/PersistedChangesetValidatorTest.java
+++ b/liquigraph-core/src/test/java/org/liquigraph/core/validation/PersistedChangesetValidatorTest.java
@@ -45,7 +45,7 @@ public class PersistedChangesetValidatorTest {
     public void passes_if_all_existing_changesets_have_not_changed_checksum() {
         Collection<String> errors = validator.validate(
             newArrayList(changeset("identifier", "author", "MATCH m RETURN m")),
-            newArrayList(changeset("identifier", "author2", "MATCH m RETURN m"))
+            newArrayList(changeset("identifier", "author", "MATCH m RETURN m"))
         );
 
         assertThat(errors).isEmpty();
@@ -65,12 +65,12 @@ public class PersistedChangesetValidatorTest {
     public void fails_if_changesets_with_same_id_have_different_checksums() throws Exception {
         Collection<String> errors = validator.validate(
             newArrayList(changeset("identifier", "author", "MATCH m RETURN m")),
-            newArrayList(changeset("identifier", "author2", "MATCH (m)-->(z) RETURN m, z"))
+            newArrayList(changeset("identifier", "author", "MATCH (m)-->(z) RETURN m, z"))
         );
 
         assertThat(errors).containsExactly(
             format(
-                "Changeset with ID <identifier> has conflicted checksums.\n" +
+                "Changeset with ID <identifier> and author <author> has conflicted checksums.\n" +
                 "\t - Declared: <%s>\n" +
                 "\t - Persisted: <%s>.",
                 checksum(singletonList("MATCH m RETURN m")),
@@ -81,7 +81,7 @@ public class PersistedChangesetValidatorTest {
 
     private Changeset changeset(String identifier, String author, String query, boolean runOnChange) {
         Changeset changeset = changeset(identifier, author, query);
-        changeset.setRunOnChange(true);
+        changeset.setRunOnChange(runOnChange);
         return changeset;
     }
 


### PR DESCRIPTION
I've made sure the changeset are uniquely identified by the (id, author) tuple, as documented, across Cypher queries and Java code (`Changeset::equals`, predicates).

While adding unit tests on the predicates, I found that run-on-change changesets were incorrectly selected for running again when they had *not* changed, instead of when they had *actually* changed. Unit tests FTW 😄.