### PR TITLE
[#59] Run tests against provisioned Neo4j instance

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,12 @@
-sudo: false
+sudo: required
 cache:
   directories:
     - $HOME/.m2
 language: java
-install: true
+services:
+  - docker
 jdk:
-- openjdk7
+#- openjdk7
 - oraclejdk7
 - oraclejdk8
 os:
@@ -13,12 +14,26 @@ os:
 env:
   matrix:
     - NEO_VERSION=2.0.5
+      WITH_DOCKER=false
     - NEO_VERSION=2.1.8
+      WITH_DOCKER=false
     - NEO_VERSION=2.2.9
+      WITH_DOCKER=false
       EXTRA_PROFILES=-Pwith-neo4j-io
     - NEO_VERSION=2.3.3
+      WITH_DOCKER=true
       EXTRA_PROFILES=-Pwith-neo4j-io
-script: "mvn -T4 clean test -Dneo4j.version=${NEO_VERSION} ${EXTRA_PROFILES}"
+before_script:
+# Workaround for Travis CI buffer overflow with OpenJDK 7
+# Details: https://github.com/travis-ci/travis-ci/issues/5227#issuecomment-165131913
+  - cat /etc/hosts
+  - echo "$(hostname | cut -c1-63)"
+  - sudo hostname "$(hostname | cut -c1-63)"
+  - sed -e "s/^\\(127\\.0\\.0\\.1.*\\)/\\1 $(hostname | cut -c1-63)/" /etc/hosts | sudo tee /etc/hosts
+  - cat /etc/hosts
+# End of workaround
+script: build/run.sh
+install: true
 after_success:
   - mvn clean test jacoco:report coveralls:report
   - "[ ${TRAVIS_PULL_REQUEST} = 'false' ] && [ ${TRAVIS_BRANCH} = 'master' ] && mvn clean deploy -DskipTests --settings ./deploy-settings.xml"

--- a/build/run.sh
+++ b/build/run.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+set -e
+if [ "$WITH_DOCKER" = true ] ; then
+    docker pull neo4j:${NEO_VERSION}
+    docker run --detach --publish=7474:7474 --volume=$HOME/neo4j/data:/data --env=NEO4J_AUTH=neo4j/j4oen neo4j
+fi
+mvn -T4 clean test -Dneo4j.version=${NEO_VERSION} ${EXTRA_PROFILES}

--- a/liquigraph-core/src/test/java/org/liquigraph/core/GraphDatabaseRule.java
+++ b/liquigraph-core/src/test/java/org/liquigraph/core/GraphDatabaseRule.java
@@ -1,0 +1,29 @@
+/**
+ * Copyright 2014-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.liquigraph.core;
+
+import com.google.common.base.Optional;
+import org.junit.rules.TestRule;
+
+import java.sql.Connection;
+
+public interface GraphDatabaseRule extends TestRule {
+
+    Connection connection();
+    String uri();
+    Optional<String> username();
+    Optional<String> password();
+}

--- a/liquigraph-core/src/test/java/org/liquigraph/core/GraphIntegrationTestSuite.java
+++ b/liquigraph-core/src/test/java/org/liquigraph/core/GraphIntegrationTestSuite.java
@@ -1,0 +1,21 @@
+/**
+ * Copyright 2014-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.liquigraph.core;
+
+public interface GraphIntegrationTestSuite {
+
+    GraphDatabaseRule graphDatabase();
+}

--- a/liquigraph-core/src/test/java/org/liquigraph/core/api/LiquigraphEmbeddedTest.java
+++ b/liquigraph-core/src/test/java/org/liquigraph/core/api/LiquigraphEmbeddedTest.java
@@ -1,0 +1,31 @@
+/**
+ * Copyright 2014-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.liquigraph.core.api;
+
+import org.junit.Rule;
+import org.liquigraph.core.EmbeddedGraphDatabaseRule;
+import org.liquigraph.core.GraphDatabaseRule;
+
+public class LiquigraphEmbeddedTest extends LiquigraphTestSuite {
+
+    @Rule
+    public GraphDatabaseRule graph = new EmbeddedGraphDatabaseRule("neo");
+
+    @Override
+    public GraphDatabaseRule graphDatabase() {
+        return graph;
+    }
+}

--- a/liquigraph-core/src/test/java/org/liquigraph/core/api/LiquigraphRemoteTest.java
+++ b/liquigraph-core/src/test/java/org/liquigraph/core/api/LiquigraphRemoteTest.java
@@ -1,0 +1,31 @@
+/**
+ * Copyright 2014-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.liquigraph.core.api;
+
+import org.junit.Rule;
+import org.liquigraph.core.GraphDatabaseRule;
+import org.liquigraph.core.RemoteGraphDatabaseRule;
+
+public class LiquigraphRemoteTest extends LiquigraphTestSuite {
+
+    @Rule
+    public GraphDatabaseRule graph = new RemoteGraphDatabaseRule();
+
+    @Override
+    public GraphDatabaseRule graphDatabase() {
+        return graph;
+    }
+}

--- a/liquigraph-core/src/test/java/org/liquigraph/core/io/ChangelogGraphReaderEmbeddedTest.java
+++ b/liquigraph-core/src/test/java/org/liquigraph/core/io/ChangelogGraphReaderEmbeddedTest.java
@@ -1,0 +1,31 @@
+/**
+ * Copyright 2014-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.liquigraph.core.io;
+
+import org.junit.Rule;
+import org.liquigraph.core.EmbeddedGraphDatabaseRule;
+import org.liquigraph.core.GraphDatabaseRule;
+
+public class ChangelogGraphReaderEmbeddedTest extends ChangelogGraphReaderTestSuite {
+
+    @Rule
+    public GraphDatabaseRule graph = new EmbeddedGraphDatabaseRule("neotestreader");
+
+    @Override
+    public GraphDatabaseRule graphDatabase() {
+        return graph;
+    }
+}

--- a/liquigraph-core/src/test/java/org/liquigraph/core/io/ChangelogGraphReaderRemoteTest.java
+++ b/liquigraph-core/src/test/java/org/liquigraph/core/io/ChangelogGraphReaderRemoteTest.java
@@ -1,0 +1,31 @@
+/**
+ * Copyright 2014-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.liquigraph.core.io;
+
+import org.junit.Rule;
+import org.liquigraph.core.EmbeddedGraphDatabaseRule;
+import org.liquigraph.core.GraphDatabaseRule;
+import org.liquigraph.core.RemoteGraphDatabaseRule;
+
+public class ChangelogGraphReaderRemoteTest extends ChangelogGraphReaderTestSuite {
+
+    @Rule public GraphDatabaseRule graph = new RemoteGraphDatabaseRule();
+
+    @Override
+    public GraphDatabaseRule graphDatabase() {
+        return graph;
+    }
+}

--- a/liquigraph-core/src/test/java/org/liquigraph/core/io/ChangelogGraphReaderTestSuite.java
+++ b/liquigraph-core/src/test/java/org/liquigraph/core/io/ChangelogGraphReaderTestSuite.java
@@ -15,9 +15,8 @@
  */
 package org.liquigraph.core.io;
 
-import org.junit.Rule;
 import org.junit.Test;
-import org.liquigraph.core.EmbeddedGraphDatabaseRule;
+import org.liquigraph.core.GraphIntegrationTestSuite;
 import org.liquigraph.core.model.Changeset;
 
 import java.sql.Connection;
@@ -30,14 +29,13 @@ import static java.util.Collections.singletonList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.liquigraph.core.model.Checksums.checksum;
 
-public class ChangelogGraphReaderTest {
+abstract class ChangelogGraphReaderTestSuite implements GraphIntegrationTestSuite {
 
-    @Rule public EmbeddedGraphDatabaseRule graph = new EmbeddedGraphDatabaseRule("neotest");
     private ChangelogGraphReader reader = new ChangelogGraphReader();
 
     @Test
     public void reads_changelog_from_graph_database() throws SQLException {
-        try (Connection connection = graph.jdbcConnection()) {
+        try (Connection connection = graphDatabase().connection()) {
             String query = "MATCH n RETURN n";
             given_inserted_data(format(
                 "CREATE (:__LiquigraphChangelog)<-[:EXECUTED_WITHIN_CHANGELOG {time:1}]-" +
@@ -50,7 +48,7 @@ public class ChangelogGraphReaderTest {
                 connection
             );
 
-            Collection<Changeset> changesets = reader.read(graph.jdbcConnection());
+            Collection<Changeset> changesets = reader.read(graphDatabase().connection());
 
             assertThat(changesets).hasSize(1);
             Changeset changeset = changesets.iterator().next();
@@ -64,7 +62,7 @@ public class ChangelogGraphReaderTest {
 
     @Test
     public void reads_changeset_with_multiple_queries() throws SQLException {
-        try (Connection connection = graph.jdbcConnection()) {
+        try (Connection connection = graphDatabase().connection()) {
             given_inserted_data(format(
                 "CREATE     (:__LiquigraphChangelog)<-[:EXECUTED_WITHIN_CHANGELOG {time:1}]-" +
                     "           (changeset:__LiquigraphChangeset {" +
@@ -82,7 +80,7 @@ public class ChangelogGraphReaderTest {
                 connection
             );
 
-            Collection<Changeset> changesets = reader.read(graph.jdbcConnection());
+            Collection<Changeset> changesets = reader.read(graphDatabase().connection());
 
             assertThat(changesets).hasSize(1);
             Changeset changeset = changesets.iterator().next();

--- a/liquigraph-core/src/test/java/org/liquigraph/core/io/ChangelogGraphWriterEmbeddedTest.java
+++ b/liquigraph-core/src/test/java/org/liquigraph/core/io/ChangelogGraphWriterEmbeddedTest.java
@@ -1,0 +1,31 @@
+/**
+ * Copyright 2014-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.liquigraph.core.io;
+
+import org.junit.Rule;
+import org.liquigraph.core.EmbeddedGraphDatabaseRule;
+import org.liquigraph.core.GraphDatabaseRule;
+
+public class ChangelogGraphWriterEmbeddedTest extends ChangelogGraphWriterTestSuite {
+
+    @Rule
+    public GraphDatabaseRule graph = new EmbeddedGraphDatabaseRule("neotestwriter");
+
+    @Override
+    public GraphDatabaseRule graphDatabase() {
+        return graph;
+    }
+}

--- a/liquigraph-core/src/test/java/org/liquigraph/core/io/ChangelogGraphWriterRemoteTest.java
+++ b/liquigraph-core/src/test/java/org/liquigraph/core/io/ChangelogGraphWriterRemoteTest.java
@@ -1,0 +1,32 @@
+/**
+ * Copyright 2014-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.liquigraph.core.io;
+
+import org.junit.Rule;
+import org.liquigraph.core.EmbeddedGraphDatabaseRule;
+import org.liquigraph.core.GraphDatabaseRule;
+import org.liquigraph.core.RemoteGraphDatabaseRule;
+
+public class ChangelogGraphWriterRemoteTest extends ChangelogGraphWriterTestSuite {
+
+    @Rule
+    public GraphDatabaseRule graph = new RemoteGraphDatabaseRule();
+
+    @Override
+    public GraphDatabaseRule graphDatabase() {
+        return graph;
+    }
+}

--- a/liquigraph-core/src/test/java/org/liquigraph/core/io/GraphJdbcConnectorTest.java
+++ b/liquigraph-core/src/test/java/org/liquigraph/core/io/GraphJdbcConnectorTest.java
@@ -15,7 +15,6 @@
  */
 package org.liquigraph.core.io;
 
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -28,6 +27,7 @@ import java.sql.SQLException;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.data.MapEntry.entry;
+import static org.liquigraph.core.RemoteGraphDatabaseRule.assumeRemoteGraphDatabaseIsProvisioned;
 
 public class GraphJdbcConnectorTest {
 
@@ -50,21 +50,18 @@ public class GraphJdbcConnectorTest {
     }
 
     @Test
-    @Ignore("requires starting local Neo4j instance")
     public void instantiates_a_remote_graph_database() throws SQLException {
+        assumeRemoteGraphDatabaseIsProvisioned();
+
         try (Connection connection = connector.connect(new ConfigurationBuilder()
             .withRunMode()
-            .withMasterChangelogLocation("changelog.xml")
-            .withUri("jdbc:neo4j://localhost:7474")
+            .withMasterChangelogLocation("changelog/changelog.xml")
+            .withUri("jdbc:neo4j://127.0.0.1:7474")
             .withUsername("neo4j")
-            .withPassword("toto")
+            .withPassword("j4oen")
             .build()
         )) {
-
-            assertThat(((Neo4jConnection) connection).getProperties()).contains(
-                entry("user", "neo4j"),
-                entry("password", "toto")
-            );
+            assertThat(connection).isInstanceOf(LockableConnection.class);
         }
     }
 

--- a/liquigraph-core/src/test/java/org/liquigraph/core/io/PreconditionExecutorTest.java
+++ b/liquigraph-core/src/test/java/org/liquigraph/core/io/PreconditionExecutorTest.java
@@ -48,7 +48,7 @@ public class PreconditionExecutorTest {
 
     @Test
     public void executes_simple_precondition() throws SQLException {
-        Connection connection = graphDatabaseRule.jdbcConnection();
+        Connection connection = graphDatabaseRule.connection();
         try (Statement ignored = connection.createStatement()) {
             PreconditionResult result = executor.executePrecondition(
                 connection,
@@ -62,7 +62,7 @@ public class PreconditionExecutorTest {
 
     @Test
     public void executes_nested_and_precondition_queries() throws SQLException {
-        Connection connection = graphDatabaseRule.jdbcConnection();
+        Connection connection = graphDatabaseRule.connection();
         try (Statement ignored = connection.createStatement()) {
             PreconditionResult result = executor.executePrecondition(
                 connection,
@@ -76,7 +76,7 @@ public class PreconditionExecutorTest {
 
     @Test
     public void executes_nested_or_precondition_queries() throws SQLException {
-        Connection connection = graphDatabaseRule.jdbcConnection();
+        Connection connection = graphDatabaseRule.connection();
         try (Statement ignored = connection.createStatement()) {
             PreconditionResult result = executor.executePrecondition(
                 connection,
@@ -98,7 +98,7 @@ public class PreconditionExecutorTest {
         ));
         precondition.setQuery(andQuery);
 
-        Connection connection = graphDatabaseRule.jdbcConnection();
+        Connection connection = graphDatabaseRule.connection();
         try (Statement ignored = connection.createStatement()) {
             PreconditionResult result = executor.executePrecondition(
                 connection,
@@ -119,7 +119,7 @@ public class PreconditionExecutorTest {
             "\tActual cause: Error executing query toto\n" +
             " with params {}");
 
-        Connection connection = graphDatabaseRule.jdbcConnection();
+        Connection connection = graphDatabaseRule.connection();
         try (Statement ignored = connection.createStatement()) {
             executor.executePrecondition(
                 connection,
@@ -133,7 +133,7 @@ public class PreconditionExecutorTest {
         thrown.expect(PreconditionExecutionException.class);
         thrown.expectMessage("Make sure your query <RETURN true> yields exactly one column named or aliased 'result'.");
 
-        Connection connection = graphDatabaseRule.jdbcConnection();
+        Connection connection = graphDatabaseRule.connection();
         try (Statement ignored = connection.createStatement()) {
             executor.executePrecondition(
                 connection,
@@ -149,7 +149,7 @@ public class PreconditionExecutorTest {
 
         Precondition precondition = new Precondition();
         precondition.setQuery(new PreconditionQuery() {});
-        executor.executePrecondition(graphDatabaseRule.jdbcConnection(), precondition);
+        executor.executePrecondition(graphDatabaseRule.connection(), precondition);
     }
 
     private Precondition simplePrecondition(PreconditionErrorPolicy fail, String query) {


### PR DESCRIPTION
Travis CI now provisions a Neo4j instance for the latest Neo4j
versions.

All classes that require scenarii to run against remote and
embedded instances now extend `GraphIntegrationTestSuite`.