### PR TITLE
Manage a single lock for a connector with multiple connections

### DIFF
--- a/liquigraph-core/src/main/java/org/liquigraph/core/io/GraphJdbcConnector.java
+++ b/liquigraph-core/src/main/java/org/liquigraph/core/io/GraphJdbcConnector.java
@@ -18,6 +18,7 @@ package org.liquigraph.core.io;
 import com.google.common.base.Optional;
 import com.google.common.base.Throwables;
 import org.liquigraph.core.configuration.Configuration;
+import org.liquigraph.core.io.lock.LiquigraphLock;
 import org.liquigraph.core.io.lock.LockableConnection;
 
 import java.sql.Connection;
@@ -25,6 +26,7 @@ import java.sql.DriverManager;
 import java.sql.SQLException;
 
 public class GraphJdbcConnector implements LiquigraphJdbcConnector {
+    private final LiquigraphLock lock = new LiquigraphLock();
 
     /**
      * Acquires a new connection to the configured instance
@@ -40,7 +42,7 @@ public class GraphJdbcConnector implements LiquigraphJdbcConnector {
             Class.forName("org.neo4j.jdbc.Driver");
             Connection connection = DriverManager.getConnection(makeUri(configuration));
             connection.setAutoCommit(false);
-            return LockableConnection.acquire(connection);
+            return LockableConnection.acquire(connection, lock);
         } catch (ClassNotFoundException | SQLException e) {
             throw Throwables.propagate(e);
         }

--- a/liquigraph-core/src/main/java/org/liquigraph/core/io/lock/LiquigraphLock.java
+++ b/liquigraph-core/src/main/java/org/liquigraph/core/io/lock/LiquigraphLock.java
@@ -1,0 +1,133 @@
+/**
+ * Copyright 2014-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.liquigraph.core.io.lock;
+
+import org.liquigraph.core.exception.LiquigraphLockException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.ArrayList;
+import java.util.Set;
+import java.util.UUID;
+
+import static com.google.common.collect.Sets.newIdentityHashSet;
+
+/**
+ * Shared lock proxy using references on the connections to create and remove the lock node, more or less like
+ * performing garbage collection by reference counting. It keeps references instead of simply counting to be able to
+ * remove the lock using the shutdown hook.
+ */
+public class LiquigraphLock {
+    private static final Logger LOGGER = LoggerFactory.getLogger(LiquigraphLock.class);
+
+    private final UUID uuid = UUID.randomUUID();
+    private final Set<Connection> connections = newIdentityHashSet();
+    private final Thread task = new Thread(new ShutdownTask(this));
+
+    void acquire(Connection connection) {
+        if (addConnection(connection)) {
+            addShutdownHook();
+            ensureLockUnicity(connection);
+            tryWriteLock(connection);
+        }
+    }
+
+    void release(Connection connection) {
+        if (removeConnection(connection)) {
+            removeShutdownHook();
+            releaseLock(connection);
+        }
+    }
+
+    void release() {
+        for (Connection connection : new ArrayList<>(connections)) {
+            release(connection);
+        }
+    }
+
+    private boolean addConnection(Connection connection) {
+        boolean wasEmpty = connections.isEmpty();
+        connections.add(connection);
+        return wasEmpty;
+    }
+
+    private boolean removeConnection(Connection connection) {
+        if (connections.isEmpty()) {
+            return false;
+        }
+        connections.remove(connection);
+        return connections.isEmpty();
+    }
+
+    private void addShutdownHook() {
+        Runtime.getRuntime().addShutdownHook(task);
+    }
+
+    private void removeShutdownHook() {
+        Runtime.getRuntime().removeShutdownHook(task);
+    }
+
+    private void ensureLockUnicity(Connection connection) {
+        try (Statement statement = connection.createStatement()) {
+            statement.execute("CREATE CONSTRAINT ON (lock:__LiquigraphLock) ASSERT lock.name IS UNIQUE");
+            connection.commit();
+        }
+        catch (SQLException e) {
+            throw new LiquigraphLockException(
+                    "Could not ensure __LiquigraphLock unicity\n\t" +
+                            "Please make sure your instance is in a clean state\n\t" +
+                            "No more than 1 lock should be there simultaneously!",
+                    e
+            );
+        }
+    }
+
+    private void tryWriteLock(Connection connection) {
+        try (PreparedStatement statement = connection.prepareStatement(
+                "CREATE (:__LiquigraphLock {name:'John', uuid:{1}})")) {
+
+            statement.setString(1, uuid.toString());
+            statement.execute();
+            connection.commit();
+        }
+        catch (SQLException e) {
+            throw new LiquigraphLockException(
+                    "Cannot create __LiquigraphLock lock\n\t" +
+                            "Likely another Liquigraph execution is going on or has crashed.",
+                    e
+            );
+        }
+    }
+
+    private void releaseLock(Connection connection) {
+        try (PreparedStatement statement = connection.prepareStatement(
+                "MATCH (lock:__LiquigraphLock {uuid:{1}}) DELETE lock")) {
+
+            statement.setString(1, uuid.toString());
+            statement.execute();
+            connection.commit();
+        } catch (SQLException e) {
+            LOGGER.error(
+                    "Cannot remove __LiquigraphLock during cleanup.",
+                    e
+            );
+        }
+    }
+}

--- a/liquigraph-core/src/test/java/org/liquigraph/core/io/lock/LiquigraphLockTest.java
+++ b/liquigraph-core/src/test/java/org/liquigraph/core/io/lock/LiquigraphLockTest.java
@@ -1,0 +1,161 @@
+/**
+ * Copyright 2014-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.liquigraph.core.io.lock;
+
+import org.assertj.core.api.ThrowableAssert;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.liquigraph.core.exception.LiquigraphLockException;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+import java.sql.Statement;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Answers.RETURNS_DEEP_STUBS;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Matchers.matches;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyZeroInteractions;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class LiquigraphLockTest {
+    @InjectMocks
+    private LiquigraphLock lock;
+    @Mock(answer = RETURNS_DEEP_STUBS)
+    private Connection connection;
+    @Mock
+    private PreparedStatement createStatement;
+    @Mock
+    private PreparedStatement deleteStatement;
+
+    @Before
+    public void setUpConnection()
+            throws SQLException {
+        when(connection.prepareStatement(matches("CREATE\\s+\\(\\w*:__LiquigraphLock[^)]*\\).*")))
+                .thenReturn(createStatement);
+        when(connection.prepareStatement(matches("MATCH\\s+\\((\\w+):__LiquigraphLock[^)]*\\)\\s+DELETE\\s+\\1")))
+                .thenReturn(deleteStatement);
+    }
+
+    @After
+    public void tearDown() {
+        lock.release();
+    }
+
+    @Test
+    public void should_create_the_lock()
+            throws SQLException {
+        lock.acquire(connection);
+
+        verify(createStatement).execute();
+        verify(connection, times(2)).commit();
+    }
+
+    @Test
+    public void should_create_the_lock_once()
+            throws SQLException {
+        lock.acquire(connection);
+        Connection connection2 = mock(Connection.class, RETURNS_DEEP_STUBS);
+
+        lock.acquire(connection2);
+
+        verify(createStatement).execute();
+        verify(connection, times(2)).commit();
+        verifyZeroInteractions(connection2);
+    }
+
+    @Test
+    public void should_fail_when_the_lock_cannot_be_created()
+            throws SQLException {
+        when(createStatement.execute()).thenThrow(SQLException.class);
+
+        assertThatThrownBy(new ThrowableAssert.ThrowingCallable() {
+            @Override
+            public void call() throws Throwable {
+                lock.acquire(connection);
+            }
+        }).isInstanceOf(LiquigraphLockException.class);
+    }
+
+    @Test
+    public void should_fail_when_the_lock_cannot_be_constrained()
+            throws SQLException {
+        Statement constraintStatement = mock(Statement.class);
+        when(connection.createStatement()).thenReturn(constraintStatement);
+        when(constraintStatement.execute(anyString())).thenThrow(SQLException.class);
+
+        assertThatThrownBy(new ThrowableAssert.ThrowingCallable() {
+            @Override
+            public void call() throws Throwable {
+                lock.acquire(connection);
+            }
+        }).isInstanceOf(LiquigraphLockException.class);
+    }
+
+    @Test
+    public void should_delete_the_lock()
+            throws SQLException {
+        lock.acquire(connection);
+
+        lock.release(connection);
+
+        verify(deleteStatement).execute();
+        verify(connection, times(3)).commit();
+    }
+
+    @Test
+    public void should_delete_the_lock_once()
+            throws SQLException {
+        lock.acquire(connection);
+        lock.release(connection);
+
+        lock.release(connection);
+
+        verify(deleteStatement).execute();
+        verify(connection, times(3)).commit();
+    }
+
+    @Test
+    public void should_not_fail_when_the_lock_cannot_be_deleted()
+            throws SQLException {
+        when(deleteStatement.execute()).thenThrow(SQLException.class);
+        lock.acquire(connection);
+
+        lock.release(connection);
+        verify(connection, times(2)).commit();
+    }
+
+    @Test
+    public void should_clean_up_using_an_unreleased_connection()
+            throws SQLException {
+        lock.acquire(connection);
+
+        lock.release();
+
+        verify(deleteStatement).execute();
+        verify(connection, times(3)).commit();
+    }
+}

--- a/liquigraph-core/src/test/java/org/liquigraph/core/io/lock/ShutdownTaskTest.java
+++ b/liquigraph-core/src/test/java/org/liquigraph/core/io/lock/ShutdownTaskTest.java
@@ -15,20 +15,25 @@
  */
 package org.liquigraph.core.io.lock;
 
-/**
- * Lock-related cleanup task for {@link LockableConnection}
- */
-final class ShutdownTask implements Runnable {
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
 
-    private final LiquigraphLock lock;
+import static org.mockito.Mockito.verify;
 
-    public ShutdownTask(LiquigraphLock lock) {
-        this.lock = lock;
+@RunWith(MockitoJUnitRunner.class)
+public class ShutdownTaskTest {
+    @InjectMocks
+    private ShutdownTask task;
+    @Mock
+    private LiquigraphLock lock;
+
+    @Test
+    public void should_release_lock_when_run() {
+        task.run();
+
+        verify(lock).release();
     }
-
-    @Override
-    public void run() {
-        lock.release();
-    }
-
 }


### PR DESCRIPTION
This fixes a bug discovered when porting the postcondition feature to the `master_3.x` branch: multiple connections will try to create multiple locks, because each `LockableConnection` had its own UUID.

Instead, `LockableConnections` now share a `LiquigraphLock` instance which acts as a proxy for the lock node, creating it for the first connection (i.e. the write connection used throughout the complete migration) and deleting it when the last connection is closed or on exit via the shutdown hook mechanism.