### PR TITLE
Upgrade the JDBC driver to 3.0

### DIFF
--- a/liquigraph-core/pom.xml
+++ b/liquigraph-core/pom.xml
@@ -30,7 +30,7 @@
         <dependency>
             <groupId>org.neo4j</groupId>
             <artifactId>neo4j-jdbc-driver</artifactId>
-            <version>3.0-RC1</version>
+            <version>3.0</version>
             <scope>runtime</scope>
         </dependency>
         <dependency>

--- a/liquigraph-core/src/main/java/org/liquigraph/core/io/ChangelogGraphReader.java
+++ b/liquigraph-core/src/main/java/org/liquigraph/core/io/ChangelogGraphReader.java
@@ -60,9 +60,10 @@ public class ChangelogGraphReader {
         Collection<Changeset> changesets = newArrayList();
         try (Statement statement = connection.createStatement()) {
             statement.execute(MIGRATE_PRE_1_0_RC3_CHANGELOG);
-            ResultSet result = statement.executeQuery(MATCH_CHANGESETS);
-            while (result.next()) {
-                changesets.add(mapRow(result.getObject("changeset")));
+            try (ResultSet result = statement.executeQuery(MATCH_CHANGESETS)) {
+                while (result.next()) {
+                    changesets.add(mapRow(result.getObject("changeset")));
+                }
             }
             connection.commit();
             return changesets;

--- a/liquigraph-core/src/main/java/org/liquigraph/core/io/ConditionExecutor.java
+++ b/liquigraph-core/src/main/java/org/liquigraph/core/io/ConditionExecutor.java
@@ -52,12 +52,12 @@ public class ConditionExecutor {
     }
 
     private boolean execute(Connection connection, String query) {
-        try (Statement statement = connection.createStatement()) {
-            ResultSet resultSet = statement.executeQuery(query);
+        try (Statement statement = connection.createStatement();
+             ResultSet resultSet = statement.executeQuery(query)) {
             resultSet.next();
             return resultSet.getBoolean("result");
         }
-        catch (SQLException | RuntimeException e) {
+        catch (SQLException e) {
             throw new ConditionExecutionException("%nError executing condition:%n" +
                "\tMake sure your query <%s> yields exactly one column named or aliased 'result'.%n" +
                "\tActual cause: %s", query, e.getMessage());

--- a/liquigraph-core/src/test/java/org/liquigraph/core/HttpGraphDatabaseRule.java
+++ b/liquigraph-core/src/test/java/org/liquigraph/core/HttpGraphDatabaseRule.java
@@ -99,11 +99,7 @@ public class HttpGraphDatabaseRule extends ExternalResource
             emptyDatabase();
             for (Connection connection : connections) {
                 if (!connection.isClosed()) {
-                    try {
-                        connection.close();
-                    } catch (SQLException ignored) {
-                        // Temporary bypass for https://github.com/neo4j-contrib/neo4j-jdbc/issues/58
-                    }
+                    connection.close();
                 }
             }
         } catch (SQLException e) {

--- a/liquigraph-core/src/test/java/org/liquigraph/core/io/ChangelogGraphWriterTestSuite.java
+++ b/liquigraph-core/src/test/java/org/liquigraph/core/io/ChangelogGraphWriterTestSuite.java
@@ -92,12 +92,12 @@ abstract class ChangelogGraphWriterTestSuite implements GraphIntegrationTestSuit
         writer.write(newArrayList(changeset));
 
         try (Connection connection = graphDatabase().newConnection();
-             Statement statement = connection.createStatement()) {
-            ResultSet resultSet = statement.executeQuery(
-                    "MATCH (changelog:__LiquigraphChangelog)<-[execution:EXECUTED_WITHIN_CHANGELOG]-(changeset:__LiquigraphChangeset) " +
-                            "OPTIONAL MATCH (node :SomeNode) " +
-                            "RETURN execution.order AS order, changeset, node"
-            );
+             Statement statement = connection.createStatement();
+             ResultSet resultSet = statement.executeQuery(
+                 "MATCH (changelog:__LiquigraphChangelog)<-[execution:EXECUTED_WITHIN_CHANGELOG]-(changeset:__LiquigraphChangeset) " +
+                 "OPTIONAL MATCH (node :SomeNode) " +
+                 "RETURN execution.order AS order, changeset, node"
+            )) {
             assertThat(resultSet.next()).as("No more result in result set").isFalse();
         }
     }
@@ -110,14 +110,14 @@ abstract class ChangelogGraphWriterTestSuite implements GraphIntegrationTestSuit
         writer.write(singletonList(changeset));
 
         try (Connection connection = graphDatabase().newConnection();
-             Statement statement = connection.createStatement()) {
-            ResultSet resultSet = statement.executeQuery(
-                    "OPTIONAL MATCH  (node: SomeNode) " +
-                            "WITH node " +
-                            "MATCH  (changelog:__LiquigraphChangelog)<-[ewc:EXECUTED_WITHIN_CHANGELOG]-(changeset:__LiquigraphChangeset), " +
-                            "       (changeset)<-[:EXECUTED_WITHIN_CHANGESET]-(query:__LiquigraphQuery) " +
-                            "RETURN ewc.time AS time, changeset, COLLECT(query.query) AS queries, node"
-            );
+             Statement statement = connection.createStatement();
+             ResultSet resultSet = statement.executeQuery(
+                 "OPTIONAL MATCH  (node: SomeNode) " +
+                 "WITH node " +
+                 "MATCH  (changelog:__LiquigraphChangelog)<-[ewc:EXECUTED_WITHIN_CHANGELOG]-(changeset:__LiquigraphChangeset), " +
+                 "       (changeset)<-[:EXECUTED_WITHIN_CHANGESET]-(query:__LiquigraphQuery) " +
+                 "RETURN ewc.time AS time, changeset, COLLECT(query.query) AS queries, node"
+            )) {
             assertThat(resultSet.next()).as("Result set should contain 1 row").isTrue();
             assertThatChangesetIsStored(resultSet);
             assertThatQueryIsNotExecuted(resultSet);
@@ -138,17 +138,16 @@ abstract class ChangelogGraphWriterTestSuite implements GraphIntegrationTestSuit
         writer.write(singletonList(changeset));
 
         try (Connection connection = graphDatabase().newConnection();
-             Statement transaction = connection.createStatement()) {
-
-            ResultSet resultSet = transaction.executeQuery("MATCH (n:Human) RETURN n.age AS age");
+             Statement transaction = connection.createStatement();
+             ResultSet resultSet = transaction.executeQuery("MATCH (n:Human) RETURN n.age AS age")) {
             assertThat(resultSet.next()).isTrue();
             assertThat(resultSet.getLong("age")).isEqualTo(42);
             assertThat(resultSet.next()).as("No more result in result set").isFalse();
         }
 
         try (Connection connection = graphDatabase().newConnection();
-             Statement transaction = connection.createStatement()) {
-            ResultSet resultSet = transaction.executeQuery("MATCH (queries:__LiquigraphQuery) RETURN COLLECT(queries.query) AS query");
+             Statement transaction = connection.createStatement();
+             ResultSet resultSet = transaction.executeQuery("MATCH (queries:__LiquigraphQuery) RETURN COLLECT(queries.query) AS query")) {
             assertThat(resultSet.next()).isTrue();
             assertThat((Collection<String>)resultSet.getObject("query")).containsExactly(
                 "CREATE (n:Human) RETURN n", "MATCH (n:Human) SET n.age = 42 RETURN n"
@@ -170,9 +169,9 @@ abstract class ChangelogGraphWriterTestSuite implements GraphIntegrationTestSuit
         }
 
         try (Connection connection = graphDatabase().newConnection();
-             Statement transaction = connection.createStatement()) {
-            ResultSet changesetSet = transaction.executeQuery("MATCH (changeset:__LiquigraphChangeset) RETURN changeset");
-            ResultSet propSet = transaction.executeQuery("MATCH (n:SomeNode) RETURN n.prop AS prop");
+             Statement transaction = connection.createStatement();
+             ResultSet changesetSet = transaction.executeQuery("MATCH (changeset:__LiquigraphChangeset) RETURN changeset");
+             ResultSet propSet = transaction.executeQuery("MATCH (n:SomeNode) RETURN n.prop AS prop")) {
             assertThat(changesetSet.next()).isTrue();
 
             Object changesetNode = changesetSet.getObject("changeset");
@@ -207,9 +206,9 @@ abstract class ChangelogGraphWriterTestSuite implements GraphIntegrationTestSuit
         writer.write(newArrayList(changeset));
 
         try (Connection connection = graphDatabase().newConnection();
-             Statement transaction = connection.createStatement()) {
-            ResultSet changesetSet = transaction.executeQuery("MATCH (changeset:__LiquigraphChangeset) RETURN changeset");
-            ResultSet propSet = transaction.executeQuery("MATCH (n:SomeNode) RETURN n.prop AS prop");
+             Statement transaction = connection.createStatement();
+             ResultSet changesetSet = transaction.executeQuery("MATCH (changeset:__LiquigraphChangeset) RETURN changeset");
+             ResultSet propSet = transaction.executeQuery("MATCH (n:SomeNode) RETURN n.prop AS prop")) {
             assertThat(changesetSet.next()).isTrue();
 
             Object changesetNode = changesetSet.getObject("changeset");
@@ -250,10 +249,10 @@ abstract class ChangelogGraphWriterTestSuite implements GraphIntegrationTestSuit
 
             writer.write(newArrayList(changeset));
 
-            try (Statement transaction = connection.createStatement()) {
-                ResultSet resultSet = transaction.executeQuery(
-                    "MATCH (n:SomeNode) " +
-                    "RETURN n.prop AS prop");
+            try (Statement transaction = connection.createStatement();
+                 ResultSet resultSet = transaction.executeQuery(
+                     "MATCH (n:SomeNode) " +
+                     "RETURN n.prop AS prop")) {
 
                 assertThat(resultSet.next()).isTrue();
 
@@ -300,13 +299,13 @@ abstract class ChangelogGraphWriterTestSuite implements GraphIntegrationTestSuit
 
     private void assertThatQueryIsExecutedAndHistoryPersisted() throws SQLException {
         try (Connection connection = connectionSupplier.get();
-             Statement statement = connection.createStatement()) {
-            ResultSet resultSet = statement.executeQuery(
-                    "MATCH  (node: SomeNode), " +
-                            "       (changelog:__LiquigraphChangelog)<-[ewc:EXECUTED_WITHIN_CHANGELOG]-(changeset:__LiquigraphChangeset), " +
-                            "       (changeset)<-[:EXECUTED_WITHIN_CHANGESET]-(query:__LiquigraphQuery) " +
-                            "RETURN ewc.time AS time, changeset, COLLECT(query.query) AS queries, node"
-            );
+             Statement statement = connection.createStatement();
+             ResultSet resultSet = statement.executeQuery(
+                 "MATCH  (node: SomeNode), " +
+                 "       (changelog:__LiquigraphChangelog)<-[ewc:EXECUTED_WITHIN_CHANGELOG]-(changeset:__LiquigraphChangeset), " +
+                 "       (changeset)<-[:EXECUTED_WITHIN_CHANGESET]-(query:__LiquigraphQuery) " +
+                 "RETURN ewc.time AS time, changeset, COLLECT(query.query) AS queries, node"
+            )) {
             assertThat(resultSet.next()).as("Result set should contain 1 row").isTrue();
             assertThatChangesetIsStored(resultSet);
             assertThatQueryIsExecuted(resultSet);


### PR DESCRIPTION
This allows the removal of the workarounds for the bugs found in 3.0-RC1 that
were fixed in the release.

Fixes #95