### PR TITLE
Use a regular block comment for the license header

### DIFF
--- a/liquigraph-cli/src/main/java/org/liquigraph/cli/LiquigraphCli.java
+++ b/liquigraph-cli/src/main/java/org/liquigraph/cli/LiquigraphCli.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/liquigraph-cli/src/main/resources-filtered/liquigraph-cli.properties
+++ b/liquigraph-cli/src/main/resources-filtered/liquigraph-cli.properties
@@ -1,1 +1,17 @@
+#
+# Copyright 2014-2016 the original author or authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
 liquigraph.version = ${project.version}

--- a/liquigraph-core/src/main/java/org/liquigraph/core/api/ChangelogDiffMaker.java
+++ b/liquigraph-core/src/main/java/org/liquigraph/core/api/ChangelogDiffMaker.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/liquigraph-core/src/main/java/org/liquigraph/core/api/Liquigraph.java
+++ b/liquigraph-core/src/main/java/org/liquigraph/core/api/Liquigraph.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/liquigraph-core/src/main/java/org/liquigraph/core/api/MigrationRunner.java
+++ b/liquigraph-core/src/main/java/org/liquigraph/core/api/MigrationRunner.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/liquigraph-core/src/main/java/org/liquigraph/core/configuration/Configuration.java
+++ b/liquigraph-core/src/main/java/org/liquigraph/core/configuration/Configuration.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/liquigraph-core/src/main/java/org/liquigraph/core/configuration/ConfigurationBuilder.java
+++ b/liquigraph-core/src/main/java/org/liquigraph/core/configuration/ConfigurationBuilder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/liquigraph-core/src/main/java/org/liquigraph/core/configuration/ConnectionConfiguration.java
+++ b/liquigraph-core/src/main/java/org/liquigraph/core/configuration/ConnectionConfiguration.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/liquigraph-core/src/main/java/org/liquigraph/core/configuration/ConnectionConfigurationByDataSource.java
+++ b/liquigraph-core/src/main/java/org/liquigraph/core/configuration/ConnectionConfigurationByDataSource.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/liquigraph-core/src/main/java/org/liquigraph/core/configuration/ConnectionConfigurationByUri.java
+++ b/liquigraph-core/src/main/java/org/liquigraph/core/configuration/ConnectionConfigurationByUri.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/liquigraph-core/src/main/java/org/liquigraph/core/configuration/DryRunMode.java
+++ b/liquigraph-core/src/main/java/org/liquigraph/core/configuration/DryRunMode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/liquigraph-core/src/main/java/org/liquigraph/core/configuration/ExecutionContexts.java
+++ b/liquigraph-core/src/main/java/org/liquigraph/core/configuration/ExecutionContexts.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/liquigraph-core/src/main/java/org/liquigraph/core/configuration/ExecutionMode.java
+++ b/liquigraph-core/src/main/java/org/liquigraph/core/configuration/ExecutionMode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/liquigraph-core/src/main/java/org/liquigraph/core/configuration/RunMode.java
+++ b/liquigraph-core/src/main/java/org/liquigraph/core/configuration/RunMode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/liquigraph-core/src/main/java/org/liquigraph/core/configuration/validators/DatasourceConfigurationValidator.java
+++ b/liquigraph-core/src/main/java/org/liquigraph/core/configuration/validators/DatasourceConfigurationValidator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/liquigraph-core/src/main/java/org/liquigraph/core/configuration/validators/ExecutionModeValidator.java
+++ b/liquigraph-core/src/main/java/org/liquigraph/core/configuration/validators/ExecutionModeValidator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/liquigraph-core/src/main/java/org/liquigraph/core/configuration/validators/MandatoryOptionValidator.java
+++ b/liquigraph-core/src/main/java/org/liquigraph/core/configuration/validators/MandatoryOptionValidator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/liquigraph-core/src/main/java/org/liquigraph/core/exception/ConditionExecutionException.java
+++ b/liquigraph-core/src/main/java/org/liquigraph/core/exception/ConditionExecutionException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/liquigraph-core/src/main/java/org/liquigraph/core/exception/LiquigraphLockException.java
+++ b/liquigraph-core/src/main/java/org/liquigraph/core/exception/LiquigraphLockException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/liquigraph-core/src/main/java/org/liquigraph/core/exception/PreconditionNotMetException.java
+++ b/liquigraph-core/src/main/java/org/liquigraph/core/exception/PreconditionNotMetException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/liquigraph-core/src/main/java/org/liquigraph/core/io/ChangelogFileWriter.java
+++ b/liquigraph-core/src/main/java/org/liquigraph/core/io/ChangelogFileWriter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/liquigraph-core/src/main/java/org/liquigraph/core/io/ChangelogGraphReader.java
+++ b/liquigraph-core/src/main/java/org/liquigraph/core/io/ChangelogGraphReader.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/liquigraph-core/src/main/java/org/liquigraph/core/io/ChangelogGraphWriter.java
+++ b/liquigraph-core/src/main/java/org/liquigraph/core/io/ChangelogGraphWriter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/liquigraph-core/src/main/java/org/liquigraph/core/io/ChangelogWriter.java
+++ b/liquigraph-core/src/main/java/org/liquigraph/core/io/ChangelogWriter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/liquigraph-core/src/main/java/org/liquigraph/core/io/ConditionExecutor.java
+++ b/liquigraph-core/src/main/java/org/liquigraph/core/io/ConditionExecutor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/liquigraph-core/src/main/java/org/liquigraph/core/io/ConditionPrinter.java
+++ b/liquigraph-core/src/main/java/org/liquigraph/core/io/ConditionPrinter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/liquigraph-core/src/main/java/org/liquigraph/core/io/GraphJdbcConnector.java
+++ b/liquigraph-core/src/main/java/org/liquigraph/core/io/GraphJdbcConnector.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/liquigraph-core/src/main/java/org/liquigraph/core/io/LiquigraphJdbcConnector.java
+++ b/liquigraph-core/src/main/java/org/liquigraph/core/io/LiquigraphJdbcConnector.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/liquigraph-core/src/main/java/org/liquigraph/core/io/lock/LiquigraphLock.java
+++ b/liquigraph-core/src/main/java/org/liquigraph/core/io/lock/LiquigraphLock.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/liquigraph-core/src/main/java/org/liquigraph/core/io/lock/LockableConnection.java
+++ b/liquigraph-core/src/main/java/org/liquigraph/core/io/lock/LockableConnection.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/liquigraph-core/src/main/java/org/liquigraph/core/io/lock/ShutdownTask.java
+++ b/liquigraph-core/src/main/java/org/liquigraph/core/io/lock/ShutdownTask.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/liquigraph-core/src/main/java/org/liquigraph/core/io/xml/ChangelogParser.java
+++ b/liquigraph-core/src/main/java/org/liquigraph/core/io/xml/ChangelogParser.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/liquigraph-core/src/main/java/org/liquigraph/core/io/xml/ChangelogPreprocessor.java
+++ b/liquigraph-core/src/main/java/org/liquigraph/core/io/xml/ChangelogPreprocessor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/liquigraph-core/src/main/java/org/liquigraph/core/io/xml/DomSourceValidator.java
+++ b/liquigraph-core/src/main/java/org/liquigraph/core/io/xml/DomSourceValidator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/liquigraph-core/src/main/java/org/liquigraph/core/io/xml/DomSourceValidatorFactory.java
+++ b/liquigraph-core/src/main/java/org/liquigraph/core/io/xml/DomSourceValidatorFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/liquigraph-core/src/main/java/org/liquigraph/core/io/xml/ExplicitSchemaValidator.java
+++ b/liquigraph-core/src/main/java/org/liquigraph/core/io/xml/ExplicitSchemaValidator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/liquigraph-core/src/main/java/org/liquigraph/core/io/xml/ImplicitSchemaValidator.java
+++ b/liquigraph-core/src/main/java/org/liquigraph/core/io/xml/ImplicitSchemaValidator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/liquigraph-core/src/main/java/org/liquigraph/core/io/xml/ImportResolver.java
+++ b/liquigraph-core/src/main/java/org/liquigraph/core/io/xml/ImportResolver.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/liquigraph-core/src/main/java/org/liquigraph/core/io/xml/IterableNodeList.java
+++ b/liquigraph-core/src/main/java/org/liquigraph/core/io/xml/IterableNodeList.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/liquigraph-core/src/main/java/org/liquigraph/core/io/xml/NodeListIterator.java
+++ b/liquigraph-core/src/main/java/org/liquigraph/core/io/xml/NodeListIterator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/liquigraph-core/src/main/java/org/liquigraph/core/io/xml/SchemaDetector.java
+++ b/liquigraph-core/src/main/java/org/liquigraph/core/io/xml/SchemaDetector.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/liquigraph-core/src/main/java/org/liquigraph/core/io/xml/SchemaErrorHandler.java
+++ b/liquigraph-core/src/main/java/org/liquigraph/core/io/xml/SchemaErrorHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/liquigraph-core/src/main/java/org/liquigraph/core/io/xml/XmlSchemaValidator.java
+++ b/liquigraph-core/src/main/java/org/liquigraph/core/io/xml/XmlSchemaValidator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/liquigraph-core/src/main/java/org/liquigraph/core/model/AndQuery.java
+++ b/liquigraph-core/src/main/java/org/liquigraph/core/model/AndQuery.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/liquigraph-core/src/main/java/org/liquigraph/core/model/Changelog.java
+++ b/liquigraph-core/src/main/java/org/liquigraph/core/model/Changelog.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/liquigraph-core/src/main/java/org/liquigraph/core/model/Changeset.java
+++ b/liquigraph-core/src/main/java/org/liquigraph/core/model/Changeset.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/liquigraph-core/src/main/java/org/liquigraph/core/model/Checksums.java
+++ b/liquigraph-core/src/main/java/org/liquigraph/core/model/Checksums.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/liquigraph-core/src/main/java/org/liquigraph/core/model/CompoundQueries.java
+++ b/liquigraph-core/src/main/java/org/liquigraph/core/model/CompoundQueries.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/liquigraph-core/src/main/java/org/liquigraph/core/model/CompoundQuery.java
+++ b/liquigraph-core/src/main/java/org/liquigraph/core/model/CompoundQuery.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/liquigraph-core/src/main/java/org/liquigraph/core/model/Condition.java
+++ b/liquigraph-core/src/main/java/org/liquigraph/core/model/Condition.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/liquigraph-core/src/main/java/org/liquigraph/core/model/OrQuery.java
+++ b/liquigraph-core/src/main/java/org/liquigraph/core/model/OrQuery.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/liquigraph-core/src/main/java/org/liquigraph/core/model/Postcondition.java
+++ b/liquigraph-core/src/main/java/org/liquigraph/core/model/Postcondition.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/liquigraph-core/src/main/java/org/liquigraph/core/model/Precondition.java
+++ b/liquigraph-core/src/main/java/org/liquigraph/core/model/Precondition.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/liquigraph-core/src/main/java/org/liquigraph/core/model/PreconditionErrorPolicy.java
+++ b/liquigraph-core/src/main/java/org/liquigraph/core/model/PreconditionErrorPolicy.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/liquigraph-core/src/main/java/org/liquigraph/core/model/Query.java
+++ b/liquigraph-core/src/main/java/org/liquigraph/core/model/Query.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/liquigraph-core/src/main/java/org/liquigraph/core/model/SimpleQuery.java
+++ b/liquigraph-core/src/main/java/org/liquigraph/core/model/SimpleQuery.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/liquigraph-core/src/main/java/org/liquigraph/core/model/package-info.java
+++ b/liquigraph-core/src/main/java/org/liquigraph/core/model/package-info.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/liquigraph-core/src/main/java/org/liquigraph/core/model/predicates/ChangesetById.java
+++ b/liquigraph-core/src/main/java/org/liquigraph/core/model/predicates/ChangesetById.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/liquigraph-core/src/main/java/org/liquigraph/core/model/predicates/ChangesetChecksumHasChanged.java
+++ b/liquigraph-core/src/main/java/org/liquigraph/core/model/predicates/ChangesetChecksumHasChanged.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/liquigraph-core/src/main/java/org/liquigraph/core/model/predicates/ChangesetMatchAnyExecutionContexts.java
+++ b/liquigraph-core/src/main/java/org/liquigraph/core/model/predicates/ChangesetMatchAnyExecutionContexts.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/liquigraph-core/src/main/java/org/liquigraph/core/model/predicates/ChangesetRunAlways.java
+++ b/liquigraph-core/src/main/java/org/liquigraph/core/model/predicates/ChangesetRunAlways.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/liquigraph-core/src/main/java/org/liquigraph/core/model/predicates/ChangesetRunOnChange.java
+++ b/liquigraph-core/src/main/java/org/liquigraph/core/model/predicates/ChangesetRunOnChange.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/liquigraph-core/src/main/java/org/liquigraph/core/model/predicates/ExecutionContextsMatchAnyContext.java
+++ b/liquigraph-core/src/main/java/org/liquigraph/core/model/predicates/ExecutionContextsMatchAnyContext.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/liquigraph-core/src/main/java/org/liquigraph/core/validation/PersistedChangesetValidator.java
+++ b/liquigraph-core/src/main/java/org/liquigraph/core/validation/PersistedChangesetValidator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/liquigraph-core/src/test/java/org/liquigraph/core/BoltGraphDatabaseRule.java
+++ b/liquigraph-core/src/test/java/org/liquigraph/core/BoltGraphDatabaseRule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/liquigraph-core/src/test/java/org/liquigraph/core/GraphDatabaseRule.java
+++ b/liquigraph-core/src/test/java/org/liquigraph/core/GraphDatabaseRule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/liquigraph-core/src/test/java/org/liquigraph/core/GraphIntegrationTestSuite.java
+++ b/liquigraph-core/src/test/java/org/liquigraph/core/GraphIntegrationTestSuite.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/liquigraph-core/src/test/java/org/liquigraph/core/HttpGraphDatabaseRule.java
+++ b/liquigraph-core/src/test/java/org/liquigraph/core/HttpGraphDatabaseRule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/liquigraph-core/src/test/java/org/liquigraph/core/api/ChangelogDiffMakerTest.java
+++ b/liquigraph-core/src/test/java/org/liquigraph/core/api/ChangelogDiffMakerTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/liquigraph-core/src/test/java/org/liquigraph/core/api/LiquigraphBoltTest.java
+++ b/liquigraph-core/src/test/java/org/liquigraph/core/api/LiquigraphBoltTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/liquigraph-core/src/test/java/org/liquigraph/core/api/LiquigraphHttpTest.java
+++ b/liquigraph-core/src/test/java/org/liquigraph/core/api/LiquigraphHttpTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/liquigraph-core/src/test/java/org/liquigraph/core/api/LiquigraphTestSuite.java
+++ b/liquigraph-core/src/test/java/org/liquigraph/core/api/LiquigraphTestSuite.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/liquigraph-core/src/test/java/org/liquigraph/core/configuration/ConfigurationBuilderTest.java
+++ b/liquigraph-core/src/test/java/org/liquigraph/core/configuration/ConfigurationBuilderTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/liquigraph-core/src/test/java/org/liquigraph/core/configuration/ConnectionConfigurationByDataSourceTest.java
+++ b/liquigraph-core/src/test/java/org/liquigraph/core/configuration/ConnectionConfigurationByDataSourceTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/liquigraph-core/src/test/java/org/liquigraph/core/configuration/ConnectionConfigurationByUriTest.java
+++ b/liquigraph-core/src/test/java/org/liquigraph/core/configuration/ConnectionConfigurationByUriTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/liquigraph-core/src/test/java/org/liquigraph/core/configuration/ExecutionContextsTest.java
+++ b/liquigraph-core/src/test/java/org/liquigraph/core/configuration/ExecutionContextsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/liquigraph-core/src/test/java/org/liquigraph/core/configuration/validators/DatasourceConfigurationValidatorTest.java
+++ b/liquigraph-core/src/test/java/org/liquigraph/core/configuration/validators/DatasourceConfigurationValidatorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/liquigraph-core/src/test/java/org/liquigraph/core/configuration/validators/MandatoryOptionValidatorTest.java
+++ b/liquigraph-core/src/test/java/org/liquigraph/core/configuration/validators/MandatoryOptionValidatorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/liquigraph-core/src/test/java/org/liquigraph/core/io/ChangelogFileWriterTest.java
+++ b/liquigraph-core/src/test/java/org/liquigraph/core/io/ChangelogFileWriterTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/liquigraph-core/src/test/java/org/liquigraph/core/io/ChangelogGraphReaderBoltTest.java
+++ b/liquigraph-core/src/test/java/org/liquigraph/core/io/ChangelogGraphReaderBoltTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/liquigraph-core/src/test/java/org/liquigraph/core/io/ChangelogGraphReaderHttpTest.java
+++ b/liquigraph-core/src/test/java/org/liquigraph/core/io/ChangelogGraphReaderHttpTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/liquigraph-core/src/test/java/org/liquigraph/core/io/ChangelogGraphReaderTestSuite.java
+++ b/liquigraph-core/src/test/java/org/liquigraph/core/io/ChangelogGraphReaderTestSuite.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/liquigraph-core/src/test/java/org/liquigraph/core/io/ChangelogGraphWriterBoltTest.java
+++ b/liquigraph-core/src/test/java/org/liquigraph/core/io/ChangelogGraphWriterBoltTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/liquigraph-core/src/test/java/org/liquigraph/core/io/ChangelogGraphWriterHttpTest.java
+++ b/liquigraph-core/src/test/java/org/liquigraph/core/io/ChangelogGraphWriterHttpTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/liquigraph-core/src/test/java/org/liquigraph/core/io/ChangelogGraphWriterTestSuite.java
+++ b/liquigraph-core/src/test/java/org/liquigraph/core/io/ChangelogGraphWriterTestSuite.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/liquigraph-core/src/test/java/org/liquigraph/core/io/ConditionExecutorBoltTest.java
+++ b/liquigraph-core/src/test/java/org/liquigraph/core/io/ConditionExecutorBoltTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/liquigraph-core/src/test/java/org/liquigraph/core/io/ConditionExecutorHttpTest.java
+++ b/liquigraph-core/src/test/java/org/liquigraph/core/io/ConditionExecutorHttpTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/liquigraph-core/src/test/java/org/liquigraph/core/io/ConditionExecutorTestSuite.java
+++ b/liquigraph-core/src/test/java/org/liquigraph/core/io/ConditionExecutorTestSuite.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/liquigraph-core/src/test/java/org/liquigraph/core/io/ConditionPrinterTest.java
+++ b/liquigraph-core/src/test/java/org/liquigraph/core/io/ConditionPrinterTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/liquigraph-core/src/test/java/org/liquigraph/core/io/GraphJdbcConnectorBoltTest.java
+++ b/liquigraph-core/src/test/java/org/liquigraph/core/io/GraphJdbcConnectorBoltTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/liquigraph-core/src/test/java/org/liquigraph/core/io/GraphJdbcConnectorHttpTest.java
+++ b/liquigraph-core/src/test/java/org/liquigraph/core/io/GraphJdbcConnectorHttpTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/liquigraph-core/src/test/java/org/liquigraph/core/io/GraphJdbcConnectorTestSuite.java
+++ b/liquigraph-core/src/test/java/org/liquigraph/core/io/GraphJdbcConnectorTestSuite.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/liquigraph-core/src/test/java/org/liquigraph/core/io/lock/LiquigraphLockTest.java
+++ b/liquigraph-core/src/test/java/org/liquigraph/core/io/lock/LiquigraphLockTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/liquigraph-core/src/test/java/org/liquigraph/core/io/lock/LockableConnectionTest.java
+++ b/liquigraph-core/src/test/java/org/liquigraph/core/io/lock/LockableConnectionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/liquigraph-core/src/test/java/org/liquigraph/core/io/lock/ShutdownTaskTest.java
+++ b/liquigraph-core/src/test/java/org/liquigraph/core/io/lock/ShutdownTaskTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/liquigraph-core/src/test/java/org/liquigraph/core/io/xml/DomSourceValidatorFactoryTest.java
+++ b/liquigraph-core/src/test/java/org/liquigraph/core/io/xml/DomSourceValidatorFactoryTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/liquigraph-core/src/test/java/org/liquigraph/core/io/xml/ImportResolverTest.java
+++ b/liquigraph-core/src/test/java/org/liquigraph/core/io/xml/ImportResolverTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/liquigraph-core/src/test/java/org/liquigraph/core/io/xml/SchemaDetectorTest.java
+++ b/liquigraph-core/src/test/java/org/liquigraph/core/io/xml/SchemaDetectorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/liquigraph-core/src/test/java/org/liquigraph/core/model/AndQueryTest.java
+++ b/liquigraph-core/src/test/java/org/liquigraph/core/model/AndQueryTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/liquigraph-core/src/test/java/org/liquigraph/core/model/ChangesetTest.java
+++ b/liquigraph-core/src/test/java/org/liquigraph/core/model/ChangesetTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/liquigraph-core/src/test/java/org/liquigraph/core/model/OrQueryTest.java
+++ b/liquigraph-core/src/test/java/org/liquigraph/core/model/OrQueryTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/liquigraph-core/src/test/java/org/liquigraph/core/model/PostconditionTest.java
+++ b/liquigraph-core/src/test/java/org/liquigraph/core/model/PostconditionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/liquigraph-core/src/test/java/org/liquigraph/core/model/PreconditionTest.java
+++ b/liquigraph-core/src/test/java/org/liquigraph/core/model/PreconditionTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/liquigraph-core/src/test/java/org/liquigraph/core/model/SimpleQueryTest.java
+++ b/liquigraph-core/src/test/java/org/liquigraph/core/model/SimpleQueryTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/liquigraph-core/src/test/java/org/liquigraph/core/model/predicates/ChangesetByIdTest.java
+++ b/liquigraph-core/src/test/java/org/liquigraph/core/model/predicates/ChangesetByIdTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/liquigraph-core/src/test/java/org/liquigraph/core/model/predicates/ChangesetChecksumHasChangedTest.java
+++ b/liquigraph-core/src/test/java/org/liquigraph/core/model/predicates/ChangesetChecksumHasChangedTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/liquigraph-core/src/test/java/org/liquigraph/core/parser/ChangelogParserTest.java
+++ b/liquigraph-core/src/test/java/org/liquigraph/core/parser/ChangelogParserTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/liquigraph-core/src/test/java/org/liquigraph/core/parser/DocumentElements.java
+++ b/liquigraph-core/src/test/java/org/liquigraph/core/parser/DocumentElements.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/liquigraph-core/src/test/java/org/liquigraph/core/parser/NodeFinder.java
+++ b/liquigraph-core/src/test/java/org/liquigraph/core/parser/NodeFinder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/liquigraph-core/src/test/java/org/liquigraph/core/validation/PersistedChangesetValidatorTest.java
+++ b/liquigraph-core/src/test/java/org/liquigraph/core/validation/PersistedChangesetValidatorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/liquigraph-core/src/test/java/org/liquigraph/core/validation/XmlSchemaValidatorTest.java
+++ b/liquigraph-core/src/test/java/org/liquigraph/core/validation/XmlSchemaValidatorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/liquigraph-maven-plugin/src/main/java/org/liquigraph/maven/DryRunMojo.java
+++ b/liquigraph-maven-plugin/src/main/java/org/liquigraph/maven/DryRunMojo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/liquigraph-maven-plugin/src/main/java/org/liquigraph/maven/LiquigraphMojoBase.java
+++ b/liquigraph-maven-plugin/src/main/java/org/liquigraph/maven/LiquigraphMojoBase.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/liquigraph-maven-plugin/src/main/java/org/liquigraph/maven/ProjectClassLoader.java
+++ b/liquigraph-maven-plugin/src/main/java/org/liquigraph/maven/ProjectClassLoader.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/liquigraph-maven-plugin/src/main/java/org/liquigraph/maven/RunMojo.java
+++ b/liquigraph-maven-plugin/src/main/java/org/liquigraph/maven/RunMojo.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014-2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/pom.xml
+++ b/pom.xml
@@ -42,12 +42,13 @@
             <plugin>
                 <groupId>com.mycila</groupId>
                 <artifactId>license-maven-plugin</artifactId>
-                <version>2.11</version>
+                <version>3.0</version>
                 <configuration>
                     <header>LICENSE_HEADER</header>
                     <includes>
                         <include>**/src/main/java/**</include>
                         <include>**/src/main/resources/**</include>
+                        <include>**/src/main/resources-filtered/**</include>
                         <include>**/src/test/java/**</include>
                         <include>**/src/test/resources/**</include>
                     </includes>
@@ -55,6 +56,9 @@
                         <exclude>**/liquigraph.sh</exclude>
                         <exclude>**/liquigraph.bat</exclude>
                     </excludes>
+                    <mapping>
+                        <java>SLASHSTAR_STYLE</java>
+                    </mapping>
                 </configuration>
                 <executions>
                     <execution>


### PR DESCRIPTION
The license is not Javadoc, and it's not even placed in a valid Javadoc
location (on the package declaration).