### PR TITLE
[#110] Build the Javadoc during the verify phase

### DIFF
--- a/build/run.sh
+++ b/build/run.sh
@@ -9,4 +9,4 @@ if [ "$WITH_DOCKER" = true ] ; then
         sleep 1
     done
 fi
-mvn -T4 clean test -Dneo4j.version=${NEO_VERSION} ${EXTRA_PROFILES}
+mvn -T4 clean verify -Dneo4j.version=${NEO_VERSION} ${EXTRA_PROFILES}

--- a/pom.xml
+++ b/pom.xml
@@ -88,6 +88,18 @@
                 <version>3.0.1</version>
             </plugin>
             <plugin>
+                <artifactId>maven-javadoc-plugin</artifactId>
+                <version>2.10.4</version>
+                <executions>
+                    <execution>
+                        <phase>verify</phase>
+                        <goals>
+                            <goal>javadoc</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>2.18.1</version>
             </plugin>


### PR DESCRIPTION
The verify phase is then run during the Travis builds.

Fixes #110